### PR TITLE
Add current task as authorization attribute to handle per-task XACML rules

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
@@ -158,6 +158,7 @@ internal sealed class StorageDialogportenDataMerger
         {
             Id = dialogId.CreateDeterministicSubUuidV7("DialogGuiActionGoTo"),
             Action = "write",
+            AuthorizationAttribute = "urn:altinn:task:" + instance.Process.CurrentTask.ElementId,
             Priority = DialogGuiActionPriority.Primary,
             Title = [new() { LanguageCode = "nb", Value = "Gå til skjemautfylling" }],
             Url = $"{appBaseUri}/{instance.AppId}/#/instance/{instance.Id}"


### PR DESCRIPTION
See https://digdir.slack.com/archives/C079ZFUSFMW/p1742481488051909

Adding the current process task as a authorization attribute, causes it to be built a XACML request that includes the task as a resource attribute, which then hits rules like ruleid:2 in https://altinn.studio/repos/dsb/bekymring-forbrukertjenester/raw/branch/master/App/config/authorization/policy.xml 

![image](https://github.com/user-attachments/assets/bec26948-c869-4ada-8dd2-e1205d668e1e)


