### PR TITLE
Initial approach to prioritized update stream

### DIFF
--- a/src/Altinn.DialogportenAdapter.Contracts/Constants.cs
+++ b/src/Altinn.DialogportenAdapter.Contracts/Constants.cs
@@ -3,5 +3,6 @@ namespace Altinn.DialogportenAdapter.Contracts;
 public static class Constants
 {
     public const string AdapterQueueName = "altinn.dialogportenadapter.webapi";
+    public const string AdapterHistoryQueueName = "altinn.dialogportenadapter-history.webapi";
     public const string EventSimulatorQueueName = "altinn.dialogportenadapter.eventsim";
 }

--- a/src/Altinn.DialogportenAdapter.Contracts/WolverineOptionsExtentions.cs
+++ b/src/Altinn.DialogportenAdapter.Contracts/WolverineOptionsExtentions.cs
@@ -31,4 +31,19 @@ public static class WolverineOptionsExtentions
         return opts;
     }
 
+    public static AzureServiceBusQueueListenerConfiguration ConfigureDeduplicatedQueueDefaults(
+        this AzureServiceBusQueueListenerConfiguration config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        return config.ConfigureQueue(q =>
+        {
+            // NOTE! This can ONLY be set at queue creation time
+            q.RequiresDuplicateDetection = true;
+
+            // 20 seconds is the minimum allowed by ASB duplicate detection according to
+            // https://learn.microsoft.com/en-us/azure/service-bus-messaging/duplicate-detection#duplicate-detection-window-size
+            q.DuplicateDetectionHistoryTimeWindow = TimeSpan.FromSeconds(20);
+        });
+    }
 }

--- a/src/Altinn.DialogportenAdapter.EventSimulator/Program.cs
+++ b/src/Altinn.DialogportenAdapter.EventSimulator/Program.cs
@@ -62,7 +62,7 @@ static Task BuildAndRun(string[] args)
         opts.PublishMessage<MigratePartitionCommand>()
             .ToAzureServiceBusQueue(ContractConstants.EventSimulatorQueueName);
         opts.PublishMessage<SyncInstanceCommand>()
-            .ToAzureServiceBusQueue(ContractConstants.AdapterQueueName);
+            .ToAzureServiceBusQueue(ContractConstants.AdapterHistoryQueueName);
 
         // Do we need to use duplicate detection?
         // .ConfigureQueue(x => x.RequiresDuplicateDetection = true)

--- a/src/Altinn.DialogportenAdapter.WebApi/Common/Extensions/IntExtensions.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/Extensions/IntExtensions.cs
@@ -2,5 +2,7 @@ namespace Altinn.DialogportenAdapter.WebApi.Common.Extensions;
 
 public static class IntExtensions
 {
-    public static int PercentOf(this int value, int percent) => value * percent / 100;
+    // Gives an int approximation, ensure that we always get at least 1 and round up.
+    public static int PercentOf(this int value, int percent)
+        => Math.Max((int)Math.Ceiling((decimal)value * percent / 100), 1);
 }

--- a/src/Altinn.DialogportenAdapter.WebApi/Common/Extensions/IntExtensions.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/Extensions/IntExtensions.cs
@@ -1,0 +1,6 @@
+namespace Altinn.DialogportenAdapter.WebApi.Common.Extensions;
+
+public static class IntExtensions
+{
+    public static int PercentOf(this int value, int percent) => value * percent / 100;
+}


### PR DESCRIPTION
* Make a separate queue for history stream
* Assign 80% of listeners to update stream, 20% to history stream

Fixes https://github.com/Altinn/altinn-dialogporten-adapter/issues/59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated history processing queue and exposed its name for integrations.
  * Improved error handling: 401 and 422 responses now trigger retries and move failing messages to the error queue.

* **Refactor**
  * Switched to per-queue deduplicated defaults (duplicate detection enabled).
  * Rebalanced worker capacity with an 80/20 split between main and history queues.

* **Chores**
  * Event simulator updated to publish to the history processing path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->