### PR TITLE
Add workaround for missing enterprise user handling

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ActivityDtoTransformer.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ActivityDtoTransformer.cs
@@ -18,7 +18,7 @@ internal sealed class ActivityDtoTransformer
         _registerRepository = registerRepository ?? throw new ArgumentNullException(nameof(registerRepository));
     }
 
-    public async Task<List<ActivityDto>> GetActivities(InstanceEventList events, CancellationToken cancellationToken)
+    public async Task<List<ActivityDto>> GetActivities(InstanceEventList events, InstanceOwner instanceOwner, CancellationToken cancellationToken)
     {
         var activities = new List<ActivityDto>();
         var createdFound = false;
@@ -60,7 +60,7 @@ internal sealed class ActivityDtoTransformer
                 Id = @event.Id.Value.ToVersion7(@event.Created.Value),
                 Type = activityType.Value,
                 CreatedAt = @event.Created,
-                PerformedBy = GetPerformedBy(@event.User, actorUrnByUserId),
+                PerformedBy = GetPerformedBy(@event.User, instanceOwner, actorUrnByUserId),
                 Description = activityType == DialogActivityType.Information
                     ? [ new LocalizationDto { LanguageCode = "nb", Value = eventType.ToString() } ]
                     : [ ]
@@ -72,7 +72,7 @@ internal sealed class ActivityDtoTransformer
             .Where(x => StringComparer.OrdinalIgnoreCase.Equals(x.EventType, "Saved"))
             .Aggregate((SavedActivities: new List<ActivityDto>(), PreviousActivity: (ActivityDto?)null), (state, @event) =>
             {
-                var currentActor = GetPerformedBy(@event.User, actorUrnByUserId);
+                var currentActor = GetPerformedBy(@event.User, instanceOwner, actorUrnByUserId);
                 if (IsPerformedBy(state.PreviousActivity, currentActor))
                 {
                     state.PreviousActivity.CreatedAt = @event.Created;
@@ -112,7 +112,7 @@ internal sealed class ActivityDtoTransformer
         return actorUrnByUserUrn.ToDictionary(x => int.Parse(x.Key), x => x.Value);
     }
 
-    private static ActorDto GetPerformedBy(PlatformUser user, Dictionary<int, string> actorUrnByUserId)
+    private static ActorDto GetPerformedBy(PlatformUser user, InstanceOwner instanceOwner, Dictionary<int, string> actorUrnByUserId)
     {
         if (user.UserId.HasValue && actorUrnByUserId.TryGetValue(user.UserId.Value, out var actorUrn))
         {
@@ -129,6 +129,17 @@ internal sealed class ActivityDtoTransformer
         if (!string.IsNullOrWhiteSpace(user.OrgId))
         {
             return new ActorDto { ActorType = ActorType.ServiceOwner };
+        }
+
+        // The register party query API doesn't currently support Altinn 2 enterprise users, so if we at this point are left with
+        // an unresolved user-id and the authentication level is exactly 3, it is extremely likely that this is an Altinn 2 enterprise user.
+
+        // As a workaround until the register API starts supporting these users, we will therefore assume that this is an Altinn 2 enterprise user
+        // and just return the instance owner as the actor (which should be set with an organization number, as Altinn 2 enterprise users can only access
+        // instances owned by organizations)
+        if (user is { AuthenticationLevel: 3, UserId: not null } && !string.IsNullOrWhiteSpace(instanceOwner.OrganisationNumber))
+        {
+            return new ActorDto { ActorType = ActorType.PartyRepresentative, ActorId = $"{Constants.OrganizationUrnPrefix}{instanceOwner.OrganisationNumber}" };
         }
 
         throw new InvalidOperationException($"{nameof(PlatformUser)} could not be converted to {nameof(ActorDto)}: {JsonSerializer.Serialize(user)}.");

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
@@ -95,7 +95,7 @@ internal sealed class StorageDialogportenDataMerger
             : SystemLabel.Default;
         var (party, activities) = await (
             GetPartyUrn(dto.Instance.InstanceOwner.PartyId, cancellationToken),
-            _activityDtoTransformer.GetActivities(dto.Events, cancellationToken)
+            _activityDtoTransformer.GetActivities(dto.Events, dto.Instance.InstanceOwner, cancellationToken)
         );
 
         return new DialogDto

--- a/src/Altinn.DialogportenAdapter.WebApi/HttpRequests/SyncByInstanceId.http
+++ b/src/Altinn.DialogportenAdapter.WebApi/HttpRequests/SyncByInstanceId.http
@@ -1,4 +1,4 @@
-@instanceId = 50759986/26a7cdaf-4b1b-41f5-81a1-3ab1231ff895
+@instanceId = 50055202/5f88eab6-68b5-4c7a-8cc0-4fd797b05e11
 
 ### Log into maskinporten
 // @no-log


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Ensures performer information is shown for certain enterprise users in activity timelines.
- Refactor
  - Activity processing now considers the instance owner for more accurate actor resolution.
- Chores
  - Updated the sample sync request to use a new instance ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->