### PR TITLE
feat: Add legacy HTML scope to Maskinporten configuration

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/appsettings.json
+++ b/src/Altinn.DialogportenAdapter.WebApi/appsettings.json
@@ -9,7 +9,7 @@
     "Maskinporten": {
       "Environment": "PopulateFromEnvironmentVariable",
       "TokenExchangeEnvironment": "PopulateFromEnvironmentVariable",
-      "Scope": "digdir:dialogporten.serviceprovider.admin altinn:serviceowner/instances.write digdir:dialogporten.serviceprovider altinn:serviceowner/instances.read altinn:storage/instances.syncadapter altinn:register/partylookup.admin",
+      "Scope": "digdir:dialogporten.serviceprovider.admin altinn:serviceowner/instances.write digdir:dialogporten.serviceprovider altinn:serviceowner/instances.read altinn:storage/instances.syncadapter altinn:register/partylookup.admin digdir:dialogporten.serviceprovider.legacyhtml",
       "ClientId": "TODO: Add to local secrets",
       "EncodedJwk": "TODO: Add to local secrets",
       "ExhangeToAltinnToken": true,


### PR DESCRIPTION
https://github.com/Altinn/dialogporten/issues/2734#issuecomment-3273477923

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enables access to legacy HTML content in Dialogporten by adding an additional authorization scope via Maskinporten (where applicable).
* **Chores**
  * Updated authorization configuration; all other scopes and settings remain unchanged.
  * No changes to public APIs; behavior is backward compatible and requires no user action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->