### PR TITLE
fix: new dialogs now respects syncsettings

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
@@ -39,29 +39,37 @@ internal sealed class StorageDialogportenDataMerger
         
         if (existing is null)
         {
-            storageDialog.DueAt = syncAdapterSettings.DisableSyncDueAt 
-                ? storageDialog.DueAt 
-                : null;
+            storageDialog.DueAt = syncAdapterSettings.DisableSyncDueAt
+                ? null
+                : storageDialog.DueAt;
             
-            storageDialog.Activities = syncAdapterSettings.DisableAddActivities 
-                ? storageDialog.Activities 
-                : [];
+            storageDialog.Content.Summary = syncAdapterSettings.DisableSyncContentSummary
+                ? null!
+                : storageDialog.Content.Summary;
+
+            storageDialog.Activities = syncAdapterSettings.DisableAddActivities
+                ? []
+                : storageDialog.Activities;
 
             storageDialog.Attachments = syncAdapterSettings.DisableSyncAttachments
-                ? storageDialog.Attachments
-                : [];
+                ? []
+                : storageDialog.Attachments;
 
             storageDialog.Transmissions = syncAdapterSettings.DisableAddTransmissions
-                ? storageDialog.Transmissions
-                : [];
-            
-            storageDialog.Content.Summary = syncAdapterSettings.DisableSyncContentSummary 
-                ? storageDialog.Content.Summary 
-                : null!;
-            
+                ? []
+                : storageDialog.Transmissions;
+
             storageDialog.Status = syncAdapterSettings.DisableSyncStatus
-                ? storageDialog.Status 
-                : DialogStatus.NotApplicable;
+                ? DialogStatus.NotApplicable
+                : storageDialog.Status;
+            
+            storageDialog.GuiActions = syncAdapterSettings.DisableSyncGuiActions
+                ? null!
+                : storageDialog.GuiActions; 
+            
+            storageDialog.ApiActions = syncAdapterSettings.DisableSyncApiActions
+                ? null!
+                : storageDialog.ApiActions;
             
             return storageDialog;
         }

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
@@ -75,9 +75,8 @@ internal sealed class StorageDialogportenDataMerger
             return storageDialog;
         }
 
-        var syncAdapterSettings = dto.Application.GetSyncAdapterSettings();
-
         existing.IsApiOnly = storageDialog.IsApiOnly;
+        
         existing.DueAt = syncAdapterSettings.DisableSyncDueAt
             ? existing.DueAt
             : storageDialog.DueAt;

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using Altinn.DialogportenAdapter.WebApi.Common;
 using Altinn.DialogportenAdapter.WebApi.Common.Extensions;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
@@ -35,12 +34,37 @@ internal sealed class StorageDialogportenDataMerger
     {
         var existing = dto.ExistingDialog.DeepClone();
         var storageDialog = await ToDialogDto(dto, cancellationToken);
+        
+        var syncAdapterSettings = dto.Application.GetSyncAdapterSettings();
+        
         if (existing is null)
         {
+            storageDialog.DueAt = syncAdapterSettings.DisableSyncDueAt 
+                ? storageDialog.DueAt 
+                : null;
+            
+            storageDialog.Activities = syncAdapterSettings.DisableAddActivities 
+                ? storageDialog.Activities 
+                : [];
+
+            storageDialog.Attachments = syncAdapterSettings.DisableSyncAttachments
+                ? storageDialog.Attachments
+                : [];
+
+            storageDialog.Transmissions = syncAdapterSettings.DisableAddTransmissions
+                ? storageDialog.Transmissions
+                : [];
+            
+            storageDialog.Content.Summary = syncAdapterSettings.DisableSyncContentSummary 
+                ? storageDialog.Content.Summary 
+                : null!;
+            
+            storageDialog.Status = syncAdapterSettings.DisableSyncStatus
+                ? storageDialog.Status 
+                : DialogStatus.NotApplicable;
+            
             return storageDialog;
         }
-
-        var syncAdapterSettings = dto.Application.GetSyncAdapterSettings();
 
         existing.DueAt = syncAdapterSettings.DisableSyncDueAt
             ? existing.DueAt

--- a/src/Altinn.DialogportenAdapter.WebApi/HttpRequests/SyncByInstanceId.http
+++ b/src/Altinn.DialogportenAdapter.WebApi/HttpRequests/SyncByInstanceId.http
@@ -1,4 +1,4 @@
-@instanceId = 50055202/5f88eab6-68b5-4c7a-8cc0-4fd797b05e11
+@instanceId = 51040927/5b159604-638d-456e-9c9b-b31662b4ea5a/
 
 ### Log into maskinporten
 // @no-log


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Creating new dialogs now respects AdapterSyncSettings for optional fields

## Related Issue(s)
- #60 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sync now applies adapter settings when creating new dialogs, customizing due date, summary, activities, attachments, transmissions, status, and available actions.

* **Bug Fixes**
  * When no existing dialog is found, sync settings are applied immediately before returning to ensure accurate initial data.

* **Chores**
  * Updated example request instance ID and simplified the POST sync request flow by removing status-based error checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->