### PR TITLE
fix: Prevent ID collisions for Attachment and TransmissionAttachment

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
@@ -272,7 +272,9 @@ internal sealed class StorageDialogportenDataMerger
     private TransmissionAttachmentDto CreateTransmissionAttachmentDto(DataElement data) =>
         new()
         {
-            Id = Guid.Parse(data.Id).ToVersion7(data.Created.Value),
+            // Ensure unique IDs when the same DataElement appears as both TransmissionAttachment and Attachment
+            // This prevents ID collisions that would cause conflicts in Dialogporten
+            Id = Guid.CreateVersion7(data.Created!.Value), 
             DisplayName = [new() { LanguageCode = "nb", Value = data.Filename ?? data.DataType }],
             Urls =
             [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

## Related Issue(s)
- #77

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved rare duplication issues that could cause attachments and transmission attachments to share the same identifier, preventing missing or mislinked files.
  * Improved reliability when the same data element is used across both attachments and transmissions, ensuring consistent display and access.

* **Chores**
  * Internal improvements to identifier creation for attachments to reduce collision risk. No user-facing behavior changes required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->