### PR TITLE
Fix A2 enterprise user handling

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ActivityDtoTransformer.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ActivityDtoTransformer.cs
@@ -131,17 +131,6 @@ internal sealed class ActivityDtoTransformer
             return new ActorDto { ActorType = ActorType.ServiceOwner };
         }
 
-        // The register party query API doesn't currently support Altinn 2 enterprise users, so if we at this point are left with
-        // an unresolved user-id and the authentication level is exactly 3, it is extremely likely that this is an Altinn 2 enterprise user.
-
-        // As a workaround until the register API starts supporting these users, we will therefore assume that this is an Altinn 2 enterprise user
-        // and just return the instance owner as the actor (which should be set with an organization number, as Altinn 2 enterprise users can only access
-        // instances owned by organizations)
-        if (user is { AuthenticationLevel: 3, UserId: not null } && !string.IsNullOrWhiteSpace(instanceOwner.OrganisationNumber))
-        {
-            return new ActorDto { ActorType = ActorType.PartyRepresentative, ActorId = $"{Constants.OrganizationUrnPrefix}{instanceOwner.OrganisationNumber}" };
-        }
-
         throw new InvalidOperationException($"{nameof(PlatformUser)} could not be converted to {nameof(ActorDto)}: {JsonSerializer.Serialize(user)}.");
     }
 }

--- a/src/Altinn.DialogportenAdapter.WebApi/Infrastructure/Register/IRegisterApi.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Infrastructure/Register/IRegisterApi.cs
@@ -13,7 +13,7 @@ internal sealed record PartyQueryResponse(
 );
 
 internal sealed record PartyIdentifier(
-    int PartyId,
+    int? PartyId,
     string DisplayName,
     string? PersonIdentifier,
     string? OrganizationIdentifier


### PR DESCRIPTION
This removes workaround code for missing a2 enterprise user support, and fixes a deserialization error due to partyid (currently not used) being null for enterprise users.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Behavior
  - Refined how the system identifies who performed an activity, removing an incorrect fallback and enforcing clearer resolution rules.
  - More explicit errors are returned when the performer cannot be determined.

- Bug Fixes
  - Improved accuracy of activity attribution for enterprise scenarios.

- Refactor
  - Updated internal register data model to support nullable party IDs for better alignment with external data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->