### PR TITLE
Handle TaskCancelledExceptions with infinite reschedule

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Program.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Program.cs
@@ -125,7 +125,7 @@ static void BuildAndRun(string[] args)
             .Then.MoveToErrorQueue();
 
         // 5xx errors are usually transient (upstream being down/overloaded), so try a few times with a cooldown before
-        // re-scheduling indefinitely, as is timeouts (TaskCancelledExceptions). HttpRequestExceptions indicates network issues, DNS issues, etc. which are usually
+        // re-scheduling indefinitely, as is timeouts (TaskCanceledException). HttpRequestExceptions indicates network issues, DNS issues, etc. which are usually
         // transient, so handle this the same as 5xx errors.
         opts.Policies.OnException<HttpRequestException>()
             .Or<ApiException>(x => (int)x.StatusCode >= 500)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when calling external services: timeouts (request cancellations) are now treated as transient errors and retried with the same backoff strategy used for server (5xx) responses. This reduces intermittent failures and improves success rates during brief network issues or service instability, resulting in fewer user-visible errors and more consistent operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->