### PR TITLE
Consider migrated A2 archived instances as confirmed without confirmC…

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
@@ -314,7 +314,7 @@ internal sealed class StorageDialogportenDataMerger
     {
         var instanceDerivedStatus = instance.Process?.CurrentTask?.AltinnTaskType?.ToLower() switch
         {
-            _ when instance.Status.IsArchived => (instance.CompleteConfirmations?.Count ?? 0) != 0
+            _ when instance.Status.IsArchived => IsConsideredConfirmed(instance)
                 ? InstanceDerivedStatus.ArchivedConfirmed
                 : InstanceDerivedStatus.ArchivedUnconfirmed,
             "reject" => InstanceDerivedStatus.Rejected,
@@ -347,6 +347,16 @@ internal sealed class StorageDialogportenDataMerger
         };
 
         return (instanceDerivedStatus, dialogStatus);
+    }
+
+    private static bool IsConsideredConfirmed(Instance instance)
+    {
+        if (instance.DataValues.ContainsKey("A2ArchRef")) // Archived in Altinn 2, always considered confirmed
+        {
+            return true;
+        }
+
+        return (instance.CompleteConfirmations?.Count ?? 0) != 0;
     }
 
     /// <summary>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of confirmation status detection for archived dialogs. The system now correctly identifies archived items as confirmed when they contain Altinn 2 archival references or have associated completion confirmations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->