### PR TITLE
Include migrated A1/A2 instances in history stream population

### DIFF
--- a/src/Altinn.DialogportenAdapter.EventSimulator/Infrastructure/Storage/IInstanceStreamer.cs
+++ b/src/Altinn.DialogportenAdapter.EventSimulator/Infrastructure/Storage/IInstanceStreamer.cs
@@ -109,7 +109,7 @@ internal sealed class InstanceStreamer : IInstanceStreamer
 
         // Force inclusion of all Altinn versions (1, 2, 3)
         // https://github.com/Altinn/altinn-storage/blob/f577a916d4d071c8f9e6e6e3d1bdd3c734c8e164/src/Storage/Controllers/InstancesController.cs#L229-L233
-        queryString.Add("MainVersionExclude", "99");
+        queryString.Add("MainVersionExclude", "0");
 
         var next = $"storage/api/v1/instances{queryString}";
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved instance data retrieval so the instance streaming now includes all storage versions. This ensures a more complete set of instance data is returned when viewing or processing instances, reducing missed historical or alternate-version data and improving consistency of displayed and exported instance information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->