### PR TITLE
Add missing activity enum values

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Infrastructure/Dialogporten/DialogDto.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Infrastructure/Dialogporten/DialogDto.cs
@@ -493,6 +493,16 @@ public enum DialogActivityType
     /// Indicates that a form associated with the dialog has been saved.
     /// </summary>
     FormSaved = 15,
+
+    /// <summary>
+    /// Indicates that a correspondence has been opened.
+    /// </summary>
+    CorrespondenceOpened = 16,
+
+    /// <summary>
+    /// Indicates that a correspondence has been confirmed.
+    /// </summary>
+    CorrespondenceConfirmed = 17
 }
 
 public sealed class ApiActionDto


### PR DESCRIPTION
Syncs the ActivityType enum, fixing an edge deserialization error where a adapter-tracked dialog has been updated with CorrespondenceOpened/CorrespondenceConfirmed activitities (probably only relevant for test data).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended dialog activity tracking capabilities to support new correspondence-related event types, enabling the system to distinguish between when correspondence is opened and when it is confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->