### PR TITLE
Add attachment visibility decider

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ReceiptAttachmentVisibilityDecider.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ReceiptAttachmentVisibilityDecider.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Altinn.Platform.Storage.Interface.Models;
+using Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
+
+namespace Altinn.DialogportenAdapter.WebApi.Features.Command.Sync;
+
+internal sealed class ReceiptAttachmentVisibilityDecider
+{
+    private const string RefDataAsPdfDataTypeId = "ref-data-as-pdf";
+    private const string AppOwnedContributor = "app:owned";
+    private static readonly HashSet<string> HiddenGroupingResourceKeys =
+        // Sourced from https://raw.githubusercontent.com/Altinn/altinn-receipt/main/src/backend/Altinn.Receipt/appsettings.json
+        new(["group.formdatahtml", "group.formdatasource", "group.signaturesource", "group.paymentsource", "group.activities"], StringComparer.Ordinal);
+
+    private readonly Dictionary<string, DataType> _dataTypesById;
+    private readonly HashSet<string> _dataTypeIdsExcludedFromGui;
+
+    private ReceiptAttachmentVisibilityDecider(
+        Dictionary<string, DataType> dataTypesById,
+        HashSet<string> dataTypeIdsExcludedFromGui)
+    {
+        _dataTypesById = dataTypesById;
+        _dataTypeIdsExcludedFromGui = dataTypeIdsExcludedFromGui;
+    }
+
+    public static ReceiptAttachmentVisibilityDecider Create(Application application)
+    {
+        var dataTypes = application?.DataTypes ?? [];
+
+        var dataTypesById = new Dictionary<string, DataType>(StringComparer.OrdinalIgnoreCase);
+        foreach (var dataType in dataTypes)
+        {
+            if (!string.IsNullOrWhiteSpace(dataType.Id))
+            {
+                dataTypesById[dataType.Id] = dataType;
+            }
+        }
+
+        var excludedDataTypes = dataTypes
+            .Where(ShouldExcludeFromGui)
+            .Select(dt => dt.Id)
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return new ReceiptAttachmentVisibilityDecider(dataTypesById, excludedDataTypes);
+    }
+
+    public AttachmentUrlConsumerType GetConsumerType(DataElement dataElement)
+    {
+        return ShouldBeVisible(dataElement)
+            ? AttachmentUrlConsumerType.Gui
+            : AttachmentUrlConsumerType.Api;
+    }
+
+    private bool ShouldBeVisible(DataElement? dataElement)
+    {
+        if (dataElement is null)
+        {
+            return false;
+        }
+
+        var dataTypeId = dataElement.DataType;
+        if (string.IsNullOrWhiteSpace(dataTypeId))
+        {
+            // No data type metadata means we fall back to making the attachment visible
+            return true;
+        }
+
+        if (string.Equals(dataTypeId, RefDataAsPdfDataTypeId, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (_dataTypeIdsExcludedFromGui.Contains(dataTypeId))
+        {
+            return false;
+        }
+
+        if (_dataTypesById.TryGetValue(dataTypeId, out var dataType) &&
+            !string.IsNullOrWhiteSpace(dataType.Grouping) &&
+            HiddenGroupingResourceKeys.Contains(dataType.Grouping))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool ShouldExcludeFromGui(DataType dataType)
+    {
+        if (string.IsNullOrWhiteSpace(dataType.Id))
+        {
+            return false;
+        }
+
+        if (string.Equals(dataType.Id, RefDataAsPdfDataTypeId, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (dataType.AppLogic is not null)
+        {
+            return true;
+        }
+
+        if (ContainsAppOwned(dataType.AllowedContributors))
+        {
+            return true;
+        }
+
+#pragma warning disable CS0618 // AllowedContributers is kept for backwards compatibility
+        if (ContainsAppOwned(dataType.AllowedContributers))
+        {
+#pragma warning restore CS0618
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool ContainsAppOwned(IEnumerable<string>? values) =>
+        values is not null && values.Any(value => string.Equals(value, AppOwnedContributor, StringComparison.Ordinal));
+}

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
@@ -202,10 +202,11 @@ internal sealed class StorageDialogportenDataMerger
     {
         var appSettings = dto.Application.GetSyncAdapterSettings();
         var data = dto.Instance.Data;
+        var attachmentVisibility = ReceiptAttachmentVisibilityDecider.Create(dto.Application);
         if (appSettings.DisableAddTransmissions ||
             !_settings.DialogportenAdapter.Adapter.FeatureFlag.EnableSubmissionTransmissions)
         {
-            return (data.Select(CreateAttachmentDto).ToList(), []);
+            return (data.Select(d => CreateAttachmentDto(d, attachmentVisibility)).ToList(), []);
         }
 
         var dataElementQueue = new Queue<DataElement>(data
@@ -234,7 +235,7 @@ internal sealed class StorageDialogportenDataMerger
                 },
                 Attachments = dataElementQueue
                     .DequeueWhile(e => e.LastChanged <= a.CreatedAt)
-                    .Select(CreateTransmissionAttachmentDto)
+                    .Select(e => CreateTransmissionAttachmentDto(e, attachmentVisibility))
                     .ToList()
             })
             .ToList();
@@ -242,14 +243,22 @@ internal sealed class StorageDialogportenDataMerger
         var attachments = data
             .Where(IsPerformedBySo)
             .Concat(dataElementQueue) // any remaining attachments not already included in transmissions
-            .Select(CreateAttachmentDto)
+            .Select(d => CreateAttachmentDto(d, attachmentVisibility))
             .ToList();
 
         return (attachments, transmissions);
     }
 
-    private AttachmentDto CreateAttachmentDto(DataElement data) =>
-        new()
+    private AttachmentDto CreateAttachmentDto(DataElement data, ReceiptAttachmentVisibilityDecider attachmentVisibility)
+    {
+        var consumerType = attachmentVisibility.GetConsumerType(data);
+        var platformUrl = data.SelfLinks.Platform;
+
+        var url = consumerType is AttachmentUrlConsumerType.Gui && !string.IsNullOrEmpty(platformUrl)
+            ? ToPortalUri(platformUrl)
+            : platformUrl;
+
+        return new()
         {
             Id = Guid.Parse(data.Id).ToVersion7(data.Created.Value),
             DisplayName = [new() { LanguageCode = "nb", Value = data.Filename ?? data.DataType }],
@@ -258,19 +267,26 @@ internal sealed class StorageDialogportenDataMerger
                 new()
                 {
                     Id = Guid.Parse(data.Id).ToVersion7(data.Created.Value),
-                    ConsumerType = data.Filename is not null
-                        ? AttachmentUrlConsumerType.Gui
-                        : AttachmentUrlConsumerType.Api,
+                    ConsumerType = consumerType,
                     MediaType = data.ContentType,
-                    Url = data.Filename is not null
-                        ? ToPortalUri(data.SelfLinks.Platform)
-                        : data.SelfLinks.Platform
+                    Url = url
                 }
             ]
         };
+    }
 
-    private TransmissionAttachmentDto CreateTransmissionAttachmentDto(DataElement data) =>
-        new()
+    private TransmissionAttachmentDto CreateTransmissionAttachmentDto(
+        DataElement data,
+        ReceiptAttachmentVisibilityDecider attachmentVisibility)
+    {
+        var consumerType = attachmentVisibility.GetConsumerType(data);
+        var platformUrl = data.SelfLinks.Platform;
+
+        var url = consumerType is AttachmentUrlConsumerType.Gui && !string.IsNullOrEmpty(platformUrl)
+            ? ToPortalUri(platformUrl)
+            : platformUrl;
+
+        return new()
         {
             // Ensure unique IDs when the same DataElement appears as both TransmissionAttachment and Attachment
             // This prevents ID collisions that would cause conflicts in Dialogporten
@@ -280,16 +296,13 @@ internal sealed class StorageDialogportenDataMerger
             [
                 new()
                 {
-                    ConsumerType = data.Filename is not null
-                        ? AttachmentUrlConsumerType.Gui
-                        : AttachmentUrlConsumerType.Api,
+                    ConsumerType = consumerType,
                     MediaType = data.ContentType,
-                    Url = data.Filename is not null
-                        ? ToPortalUri(data.SelfLinks.Platform)
-                        : data.SelfLinks.Platform
+                    Url = url
                 }
             ]
         };
+    }
 
     private static bool IsPerformedBySo(DataElement data)
     {

--- a/src/Altinn.DialogportenAdapter.WebApi/HttpRequests/SyncByInstanceId.http
+++ b/src/Altinn.DialogportenAdapter.WebApi/HttpRequests/SyncByInstanceId.http
@@ -1,4 +1,4 @@
-@instanceId = 51040927/5b159604-638d-456e-9c9b-b31662b4ea5a
+@instanceId = 51808024/c920f023-c369-467a-b84b-4edd6e8f5933
 
 ### Log into maskinporten
 // @no-log

--- a/src/Altinn.DialogportenAdapter.WebApi/Properties/AssemblyInfo.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Altinn.DialogportenAdapter.Unit.Tests")]

--- a/tests/Altinn.DialogportenAdapter.Unit.Tests/Altinn.DialogportenAdapter.Unit.Tests.csproj
+++ b/tests/Altinn.DialogportenAdapter.Unit.Tests/Altinn.DialogportenAdapter.Unit.Tests.csproj
@@ -26,4 +26,8 @@
         <Using Include="Xunit"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <ProjectReference Include="..\..\src/Altinn.DialogportenAdapter.WebApi/Altinn.DialogportenAdapter.WebApi.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/ReceiptAttachmentVisibilityDeciderTests.cs
+++ b/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/ReceiptAttachmentVisibilityDeciderTests.cs
@@ -1,0 +1,126 @@
+using System;
+
+using Altinn.DialogportenAdapter.WebApi.Features.Command.Sync;
+using Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
+using Altinn.Platform.Storage.Interface.Models;
+
+namespace Altinn.DialogportenAdapter.Unit.Tests.Features.Command.Sync;
+
+public class ReceiptAttachmentVisibilityDeciderTests
+{
+    [Fact]
+    public void GetConsumerType_DataTypeWithAppLogic_ReturnsApi()
+    {
+        var application = new Application
+        {
+            DataTypes =
+            [
+                new() { Id = "main", AppLogic = new ApplicationLogic() }
+            ]
+        };
+
+        var decider = ReceiptAttachmentVisibilityDecider.Create(application);
+        var result = decider.GetConsumerType(CreateDataElement("main"));
+
+        Assert.Equal(AttachmentUrlConsumerType.Api, result);
+    }
+
+    [Fact]
+    public void GetConsumerType_DataTypeWithAllowedContributorsAppOwned_ReturnsApi()
+    {
+        var application = new Application
+        {
+            DataTypes =
+            [
+                new() { Id = "attachment", AllowedContributors = ["endUser", "app:owned"] }
+            ]
+        };
+
+        var decider = ReceiptAttachmentVisibilityDecider.Create(application);
+        var result = decider.GetConsumerType(CreateDataElement("attachment"));
+
+        Assert.Equal(AttachmentUrlConsumerType.Api, result);
+    }
+
+    [Fact]
+    public void GetConsumerType_DataTypeWithLegacyAppOwnedContributers_ReturnsApi()
+    {
+        var legacyDataType = new DataType { Id = "legacy" };
+#pragma warning disable CS0618 // AllowedContributers is kept for backwards compatibility
+        legacyDataType.AllowedContributers = ["app:owned"];
+#pragma warning restore CS0618
+
+        var application = new Application
+        {
+            DataTypes = [legacyDataType]
+        };
+
+        var decider = ReceiptAttachmentVisibilityDecider.Create(application);
+        var result = decider.GetConsumerType(CreateDataElement("legacy"));
+
+        Assert.Equal(AttachmentUrlConsumerType.Api, result);
+    }
+
+    [Fact]
+    public void GetConsumerType_RefDataAsPdf_ReturnsGui()
+    {
+        var application = new Application
+        {
+            DataTypes =
+            [
+                new() { Id = "ref-data-as-pdf" }
+            ]
+        };
+
+        var decider = ReceiptAttachmentVisibilityDecider.Create(application);
+        var result = decider.GetConsumerType(CreateDataElement("ref-data-as-pdf"));
+
+        Assert.Equal(AttachmentUrlConsumerType.Gui, result);
+    }
+
+    [Fact]
+    public void GetConsumerType_DataTypeWithHiddenGrouping_ReturnsApi()
+    {
+        var application = new Application
+        {
+            DataTypes =
+            [
+                new() { Id = "formsource", Grouping = "group.formdatasource" }
+            ]
+        };
+
+        var decider = ReceiptAttachmentVisibilityDecider.Create(application);
+        var result = decider.GetConsumerType(CreateDataElement("formsource"));
+
+        Assert.Equal(AttachmentUrlConsumerType.Api, result);
+    }
+
+    [Fact]
+    public void GetConsumerType_DataTypeNotConfigured_UsesGui()
+    {
+        var application = new Application { DataTypes = [] };
+
+        var decider = ReceiptAttachmentVisibilityDecider.Create(application);
+        var result = decider.GetConsumerType(CreateDataElement("unknown"));
+
+        Assert.Equal(AttachmentUrlConsumerType.Gui, result);
+    }
+
+    [Fact]
+    public void GetConsumerType_DataElementWithoutDataType_UsesGui()
+    {
+        var application = new Application { DataTypes = [] };
+
+        var decider = ReceiptAttachmentVisibilityDecider.Create(application);
+        var result = decider.GetConsumerType(CreateDataElement(null));
+
+        Assert.Equal(AttachmentUrlConsumerType.Gui, result);
+    }
+
+    private static DataElement CreateDataElement(string? dataType) =>
+        new()
+        {
+            Id = Guid.NewGuid().ToString(),
+            DataType = dataType
+        };
+}


### PR DESCRIPTION
## Description
- Added ReceiptAttachmentVisibilityDecider with receipt-aligned filtering: app logic elements, app:owned contributors (legacy/current), explicit hidden grouping keys, and auto-GUI for ref-data-as-pdf.
- Hooked the decider into StorageDialogportenDataMerger so attachments/transmissions now set consumer type and URLs based on receipt visibility (GUI uses portal URL only whenexposed).

## Related Issue(s)
- #100 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined attachment visibility handling to better manage different consumer types in receipt processing.

* **Tests**
  * Added comprehensive unit tests for attachment visibility and consumer type logic.

* **Chores**
  * Updated test project infrastructure and assembly configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->