### PR TITLE
chore(EventSimulator): Increase timeout for MigratePartitionCommand to 10 minutes

### DIFF
--- a/src/Altinn.DialogportenAdapter.EventSimulator/Features/HistoryStream/MigrationPartitionCommandHandler.cs
+++ b/src/Altinn.DialogportenAdapter.EventSimulator/Features/HistoryStream/MigrationPartitionCommandHandler.cs
@@ -3,6 +3,7 @@ using Altinn.DialogportenAdapter.Contracts;
 using Altinn.DialogportenAdapter.EventSimulator.Common.Extensions;
 using Altinn.DialogportenAdapter.EventSimulator.Infrastructure.Persistance;
 using Altinn.DialogportenAdapter.EventSimulator.Infrastructure.Storage;
+using Wolverine.Attributes;
 
 namespace Altinn.DialogportenAdapter.EventSimulator.Features.HistoryStream;
 
@@ -69,6 +70,7 @@ public static class MigrationPartitionCommandHandler
         new(item.Partition, item.Organization);
 }
 
+[MessageTimeout(60*10)] // 10 minutes
 public sealed record MigratePartitionCommand(DateOnly Partition, string Organization, string? Party)
 {
     public bool IsTest => Party is not null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeout enforcement for partition migration operations to prevent indefinite processing delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->