### PR TITLE
Increase message timeout

### DIFF
--- a/src/Altinn.DialogportenAdapter.EventSimulator/Features/HistoryStream/MigrationPartitionCommandHandler.cs
+++ b/src/Altinn.DialogportenAdapter.EventSimulator/Features/HistoryStream/MigrationPartitionCommandHandler.cs
@@ -70,7 +70,7 @@ public static class MigrationPartitionCommandHandler
         new(item.Partition, item.Organization);
 }
 
-[MessageTimeout(60*10)] // 10 minutes
+[MessageTimeout(60*60)] // 60 minutes to handle very large partitions
 public sealed record MigratePartitionCommand(DateOnly Partition, string Organization, string? Party)
 {
     public bool IsTest => Party is not null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the message timeout for partition migration operations from 10 minutes to 60 minutes. This adjustment provides additional processing time for large-scale data migrations to complete successfully without timing out prematurely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->