### PR TITLE
Reintroduce language code filtering

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ApplicationTextParser.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ApplicationTextParser.cs
@@ -1,3 +1,4 @@
+using Altinn.DialogportenAdapter.WebApi.Common;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Storage;
 using Altinn.Platform.Storage.Interface.Models;
@@ -74,6 +75,11 @@ public static class ApplicationTextParser
         var localizations = new List<LocalizationDto>();
         foreach (var translation in applicationTexts.Translations)
         {
+            if (!LanguageCodes.IsValidTwoLetterLanguageCode(translation.Language))
+            {
+                continue;
+            }
+
             foreach (var key in keysToCheck)
             {
                 if (!translation.Texts.TryGetValue(key, out var textResource))

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
@@ -488,6 +488,7 @@ internal sealed class StorageDialogportenDataMerger
     {
         return application.Title
             .Where(x => !string.IsNullOrWhiteSpace(x.Value))
+            .Where(x => LanguageCodes.IsValidTwoLetterLanguageCode(x.Key))
             .Select(x => new LocalizationDto
             {
                 LanguageCode = x.Key,

--- a/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/ApplicationTextParserTests.cs
+++ b/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/ApplicationTextParserTests.cs
@@ -155,6 +155,33 @@ public class ApplicationTextParserTests
             });
     }
 
+    [Fact]
+    public void FiltersOutInvalidLanguageCodes()
+    {
+        var instance = CreateInstance(null);
+        var texts = CreateTexts(
+            ("nb", new Dictionary<string, string>
+            {
+                { "dp.summary", "valid" }
+            }),
+            ("xx", new Dictionary<string, string>
+            {
+                { "dp.summary", "invalid" }
+            }));
+
+        var localizations = ApplicationTextParser.GetLocalizationsFromApplicationTexts(
+            "summary",
+            instance,
+            texts,
+            InstanceDerivedStatus.AwaitingSignature);
+
+        Assert.Collection(localizations, loc =>
+        {
+            Assert.Equal("nb", loc.LanguageCode);
+            Assert.Equal("valid", loc.Value);
+        });
+    }
+
     private static Instance CreateInstance(string? taskId)
     {
         var instance = new Instance();

--- a/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/StorageDialogportenDataMergerTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/StorageDialogportenDataMergerTest.cs
@@ -1,3 +1,4 @@
+using System;
 using Altinn.DialogportenAdapter.WebApi.Features.Command.Sync;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Storage;
 using Altinn.Platform.Storage.Interface.Models;
@@ -79,18 +80,18 @@ public class StorageDialogportenDataMergerTest
         Assert.Single(localizations);
         var title = localizations.First().Value;
         Assert.Equal(255, title.Length);
-        Assert.EndsWith("a...", title);
+        Assert.EndsWith("a...", title, StringComparison.Ordinal);
         
         
         Assert.Single(summaryLocalizations);
         var summary = summaryLocalizations.First().Value;
         Assert.Equal(255, summary.Length);
-        Assert.EndsWith("b...", summary);
+        Assert.EndsWith("b...", summary, StringComparison.Ordinal);
         
         
         Assert.Single(summaryLocalizationsShort);
         var summaryShort = summaryLocalizationsShort.First().Value;
         Assert.Equal(120, summaryShort.Length);
-        Assert.EndsWith("bbb", summaryShort);
+        Assert.EndsWith("bbb", summaryShort, StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
- Application text localizations/fallbacks now skip unsupported language codes before building dialog content to avoid invalid translations
- Added regression coverage for invalid language filtering and made truncation checks culture-invariant to keep tests stable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved language code validation by filtering out invalid language codes during translation parsing and title fallback processing. Only valid two-letter language codes are now processed.

* **Tests**
  * Added unit test coverage for language code validation in localization extraction.
  * Updated existing test assertions for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->