### PR TITLE
fix: Use formsubmitted timestamp for transmission createdAt

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
@@ -242,7 +242,7 @@ internal sealed class StorageDialogportenDataMerger
             .Select((a, i) => new TransmissionDto
             {
                 Id = a.Id!.Value.ToVersion7(a.CreatedAt!.Value),
-                CreatedAt = a.CreatedAt ?? DateTimeOffset.Now,
+                CreatedAt = a.CreatedAt.Value,
                 Type = DialogTransmissionType.Submission,
                 Sender = a.PerformedBy,
                 Content = new TransmissionContentDto


### PR DESCRIPTION
## Description
This fixes setting the correct timestamp on transmissions when migrating data fra A3 (both historic and new)

## Related Issue(s)
- #120 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transmission records now consistently include creation timestamps: when a source timestamp exists it is preserved, otherwise a current timestamp is applied — improving accuracy and reliability of submission timelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->