### PR TITLE
fix: Users uploaded attachment added to transmission

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
@@ -239,7 +239,7 @@ internal sealed class StorageDialogportenDataMerger
 
         var dataElementQueue = new Queue<DataElement>(data
             .Where(x => !IsPerformedBySo(x) && x.DataType != PdfType)
-            .OrderBy(x => x.LastChanged.Value));
+            .OrderBy(x => x.Created!.Value));
 
         // A2 Instances cant have more than 1 submission
         // so we take all attachments into a single transmission.
@@ -269,7 +269,7 @@ internal sealed class StorageDialogportenDataMerger
                     }
                 },
                 Attachments = dataElementQueue
-                    .DequeueWhile(e => e.LastChanged <= a.CreatedAt || isA2)
+                    .DequeueWhile(e => e.Created <= a.CreatedAt || isA2)
                     .Select(e => CreateTransmissionAttachmentDto(e, attachmentVisibility))
                     .ToList()
             })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fixed users uploaded attachment are not always added to transmission on FormSubmitted. By ordering data elements by LastChanged and not Created

In some cases something is created early and Changed after submission. that element would then block anything created after it to be added to a transmission. 

## Related Issue(s)
- https://github.com/Altinn/dialogporten/issues/3200

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted attachment ordering to use creation timestamp when preparing transmissions, and updated grouping logic so attachments are bundled based on creation time comparisons. This changes which attachments are included in each submission transmission, improving consistency of bundle composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->