### PR TITLE
feat: Allow DueAt and VisibleFrom to be in the past during migration

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
@@ -178,8 +178,8 @@ internal sealed class StorageDialogportenDataMerger
             UpdatedAt = dto.Instance.LastChanged > dto.Instance.Created
                 ? dto.Instance.LastChanged
                 : dto.Instance.Created,
-            VisibleFrom = dto.Instance.VisibleAfter > DateTimeOffset.UtcNow ? dto.Instance.VisibleAfter : null,
-            DueAt = dto.Instance.DueBefore > DateTimeOffset.UtcNow ? dto.Instance.DueBefore : null,
+            VisibleFrom = dto.Instance.VisibleAfter > DateTimeOffset.UtcNow || dto.IsMigration ? dto.Instance.VisibleAfter : null,
+            DueAt = dto.Instance.DueBefore > DateTimeOffset.UtcNow || dto.IsMigration ? dto.Instance.DueBefore : null,
             ServiceOwnerContext = new ServiceOwnerContext
             {
                 ServiceOwnerLabels =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow DueAt and VisibleFrom to be in the past during migration

## Related Issue(s)
- #123
- Depends on https://github.com/Altinn/dialogporten/pull/3227
## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed handling of visibility and due date assignments for migrated content to ensure accurate date calculations during migration operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->