### PR TITLE
fix: Let ApiAction get source point to app instance if IsArchived == false

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
@@ -4,6 +4,7 @@ using Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Register;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Storage;
 using Altinn.Platform.Storage.Interface.Models;
+using JasperFx.Core;
 using Microsoft.Extensions.Options;
 
 namespace Altinn.DialogportenAdapter.WebApi.Features.Command.Sync;
@@ -709,12 +710,17 @@ internal sealed class StorageDialogportenDataMerger
 
     private ApiActionDto CreateGetSourceApiActionDto(Guid dialogId, Instance instance)
     {
-        var platformBaseUri = _settings.DialogportenAdapter.Altinn
-            .GetPlatformUri()
-            .ToString()
-            .TrimEnd('/');
+        var baseUri = instance.Status.IsArchived
+            ? _settings.DialogportenAdapter.Altinn
+                .GetPlatformUri()
+                .ToString()
+                .AppendUrl("/storage/api/v1")
+            : _settings.DialogportenAdapter.Altinn
+                .GetAppUriForOrg(instance.Org, instance.AppId)
+                .ToString()
+                .TrimEnd('/');
 
-        var path = $"{platformBaseUri}/storage/api/v1/instances/{instance.Id}";
+        var path = $"{baseUri}/instances/{instance.Id}";
         var apiActionId = dialogId.CreateDeterministicSubUuidV7(Constants.ApiAction.Read);
 
         var endpointDto = new ApiActionEndpointDto


### PR DESCRIPTION
## Description
If the storage instant is not archived, ApiAction get source should return an URL to the app instance

**IsArchived?**
- True: platformBaseUri/storage/api/v1/instances/53438648/9dede982-a826-48d3-9fef-3a53c4317427
- False: appBaseUri/instances/53438648/9dede982-a826-48d3-9fef-3a53c4317427

Example:
**IsArchived?**
- True: https://platform.tt02.altinn.no/storage/api/v1/instances/53438648/9dede982-a826-48d3-9fef-3a53c4317427
- False: https://udir.apps.tt02.altinn.no/udir/pbu-test-anonym/instances/53438648/9dede982-a826-48d3-9fef-3a53c4317427


<!--- Describe your changes in detail -->

## Related Issue(s)
- https://github.com/Altinn/altinn-dialogporten-adapter/issues/158

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected API endpoint selection for data synchronization—archived instances now route to the storage API endpoint, while non-archived instances use the application endpoint.
  * Ensures correct construction of instance endpoint URLs so source data is fetched from the appropriate location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->