### PR TITLE
Ignore empty translations for substatus

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
@@ -233,7 +233,7 @@ internal sealed class StorageDialogportenDataMerger
 
         var labelLocalized = dto.ApplicationTexts
             .Translations
-            .Where(t => t.Texts.ContainsKey(label))
+            .Where(t => t.Texts.TryGetValue(label, out var text) && !string.IsNullOrWhiteSpace(text))
             .Select(t => new LocalizationDto
             {
                 LanguageCode = t.Language,

--- a/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/StorageDialogportenDataMergerTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/StorageDialogportenDataMergerTest.cs
@@ -341,6 +341,18 @@ public class StorageDialogportenDataMergerTest
                             },
                         }
                     },
+                    new ApplicationTextsTranslation
+                    {
+                        Language = "es",
+                        Texts = new Dictionary<string, string>
+                        {
+                            { "substatus.label", "" },
+                            {
+                                "substatus.description",
+                                ""
+                            },
+                        }
+                    },
                 ]
             },
             DialogId: Guid.Parse("902de1ba-6919-4355-99ad-7ad279266a2f"),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)


## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation lookup logic to prevent null/empty localized values from causing runtime errors when processing status labels.

* **Tests**
  * Extended test coverage for edge cases involving empty translation values in localization mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->