### PR TITLE
fix: Update message policy to use CustomActionIndefinitely for better handling

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Program.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Program.cs
@@ -99,7 +99,7 @@ static void BuildAndRun(string[] args)
         opts.Policies
             .OnException<ApiException>(ex => ex.StatusCode is HttpStatusCode.Gone)
             .OrInner<ApiException>(ex => ex.StatusCode is HttpStatusCode.Gone)
-            .Discard();
+            .CustomActionIndefinitely((_, lifetime, _) => lifetime.CompleteAsync(), "Discard indefinitely");
 
         // If the queue backlog grows faster than we can drain it (ie. due to downtime), two messages with the same
         // InstanceId may still be processed concurrently once we catch up, causing dialog


### PR DESCRIPTION
Related issue: #182

Wolverines failure framework functions in the following way: 
1. Find first matching rule in order.
2. For that rule, pick _action slot_ by current Attempts.
3. If no slot exists (and no infinite continuation), fallback is move to error/DLQ.

So the 410 Gone rule works when it’s the first failure (attempt 1), but after prior failures under other rules, Attempts is already >1. Then Discard() has no matching slot left, and Wolverine falls through to error queue.

We could chain enough Then.Discard() slots to cover all possible attempts. But better yet, we use an indefinite policy action (custom indefinite continuation) so the 410 Gone policy allways discards, no which failure slot the message happens to be in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for 410 Gone HTTP responses by implementing asynchronous message completion logic instead of immediate discard. This improves message lifecycle management, ensures proper acknowledgment processing for deprecated resources, and enhances system reliability. The adapter now handles such responses more gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->