### PR TITLE
feat: Added handling of receipt in adapter

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Common/AuthorizationValidator.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/AuthorizationValidator.cs
@@ -1,0 +1,18 @@
+using Altinn.ApiClients.Dialogporten;
+
+namespace Altinn.DialogportenAdapter.WebApi.Common;
+
+internal sealed class AuthorizationValidator(IDialogTokenValidator dialogTokenValidator)
+{
+    private readonly IDialogTokenValidator _dialogTokenValidator = dialogTokenValidator ?? throw new ArgumentNullException(nameof(dialogTokenValidator));
+
+    public bool ValidateDialogToken(ReadOnlySpan<char> token, Guid dialogId, string[] actions)
+    {
+        const string bearerPrefix = "Bearer ";
+        token = token.StartsWith(bearerPrefix, StringComparison.OrdinalIgnoreCase)
+            ? token[bearerPrefix.Length..]
+            : token;
+        var result = _dialogTokenValidator.Validate(token, dialogId, actions);
+        return result.IsValid;
+    }
+}

--- a/src/Altinn.DialogportenAdapter.WebApi/Common/Constants.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/Constants.cs
@@ -21,6 +21,8 @@ internal static class Constants
 
     public const string DefaultMaskinportenClientDefinitionKey = "DefaultMaskinportenClientDefinitionKey";
 
+    public const string AltinnOrgsClient = "AltinnOrgsClient";
+
     public static readonly ImmutableArray<string> SupportedEventTypes =
     [
         InstanceEventType.Created.ToString(),

--- a/src/Altinn.DialogportenAdapter.WebApi/Common/MediaTypes.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/MediaTypes.cs
@@ -3,7 +3,7 @@ namespace Altinn.DialogportenAdapter.WebApi.Common;
 public static class MediaTypes
 {
     public const string EmbeddablePrefix = "application/vnd.dialogporten.frontchannelembed";
-    public const string EmbeddableMarkdown = $"{EmbeddablePrefix}+json;type=markdown";
+    public const string EmbeddableMarkdown = $"{EmbeddablePrefix}-url;type=text/markdown";
     public const string LegacyEmbeddableHtml = $"{EmbeddablePrefix}+json;type=html";
 
     public const string LegacyHtml = "text/html";

--- a/src/Altinn.DialogportenAdapter.WebApi/Common/MediaTypes.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/MediaTypes.cs
@@ -2,11 +2,9 @@ namespace Altinn.DialogportenAdapter.WebApi.Common;
 
 public static class MediaTypes
 {
-    public const string EmbeddablePrefix = "application/vnd.dialogporten.frontchannelembed";
-    public const string EmbeddableMarkdown = $"{EmbeddablePrefix}-url;type=text/markdown";
-    public const string LegacyEmbeddableHtml = $"{EmbeddablePrefix}+json;type=html";
+    public const string EmbeddablePrefix = "application/vnd.dialogporten.frontchannelembed-url";
+    public const string EmbeddableMarkdown = $"{EmbeddablePrefix};type=text/markdown";
 
-    public const string LegacyHtml = "text/html";
     public const string Markdown = "text/markdown";
     public const string PlainText = "text/plain";
 }

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/InstanceReceipt.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/InstanceReceipt.cs
@@ -1,0 +1,219 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Altinn.DialogportenAdapter.WebApi.Common.Extensions;
+using Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
+using Altinn.DialogportenAdapter.WebApi.Infrastructure.Register;
+using Altinn.DialogportenAdapter.WebApi.Infrastructure.Storage;
+using Altinn.Platform.Storage.Interface.Models;
+using static Altinn.DialogportenAdapter.WebApi.Features.Command.Sync.UrnParser;
+
+namespace Altinn.DialogportenAdapter.WebApi.Features.Command.Sync;
+
+internal sealed record GetReceiptDto(
+    Guid DialogId,
+    Guid TransmissionId,
+    string? LanguageCode);
+
+public abstract record GetReceiptResponse
+{
+    public sealed record Success(string Markdown) : GetReceiptResponse;
+
+    public sealed record NotFound : GetReceiptResponse;
+
+    public sealed record InvalidLanguageCode : GetReceiptResponse;
+}
+
+internal sealed class InstanceReceipt(
+    IStorageApi storageApi,
+    IApplicationRepository applicationRepository,
+    IDialogportenApi dialogportenApi,
+    IAltinnOrgs altinnOrgs,
+    IRegisterApi registerApi
+    )
+{
+    private readonly IStorageApi _storageApi = storageApi ?? throw new ArgumentNullException(nameof(storageApi));
+    private readonly IApplicationRepository _applicationRepository = applicationRepository ?? throw new ArgumentNullException(nameof(applicationRepository));
+    private readonly IDialogportenApi _dialogportenApi = dialogportenApi ?? throw new ArgumentNullException(nameof(dialogportenApi));
+    private readonly IAltinnOrgs _altinnOrgs = altinnOrgs ?? throw new ArgumentNullException(nameof(altinnOrgs));
+    private readonly IRegisterApi _registerApi = registerApi ?? throw new ArgumentNullException(nameof(registerApi));
+
+    private const string DefaultLanguageCode = "nb";
+    private const string InstanceReceiptSummaryKey = "receipt-transmission-summary";
+
+    private static readonly List<string> LanguageCodes = ["nb", "nn", "en"];
+
+    public static string GetSupportedLanguageCodes() => string.Join(", ", LanguageCodes);
+
+    public async Task<GetReceiptResponse> GetReceipt(GetReceiptDto request, CancellationToken cancellationToken)
+    {
+        if (request.LanguageCode is not null && !LanguageCodes.Contains(request.LanguageCode))
+            return new GetReceiptResponse.InvalidLanguageCode();
+
+        var dialog = await _dialogportenApi.Get(request.DialogId, cancellationToken).ContentOrDefault();
+        if (dialog is null)
+            return new GetReceiptResponse.NotFound();
+
+        if (!TryParseStorageUrn(dialog.ServiceOwnerContext?.ServiceOwnerLabels.FirstOrDefault()?.Value,
+                out string? partyId, out var instanceGuid))
+            return new GetReceiptResponse.NotFound();
+
+        var instance = await _storageApi.GetInstance(partyId, instanceGuid, cancellationToken)
+            .ContentOrDefault();
+        if (instance is null)
+            return new GetReceiptResponse.NotFound();
+
+        var application = await _applicationRepository.GetApplication(instance.AppId, cancellationToken);
+        if (application is null)
+            return new GetReceiptResponse.NotFound();
+
+        var transmission = dialog.Transmissions.FirstOrDefault(x => x.Id == request.TransmissionId);
+        if (transmission is null)
+            return new GetReceiptResponse.NotFound();
+
+        var orgs = await _altinnOrgs.GetAltinnOrgs(cancellationToken);
+
+        var langCode = request.LanguageCode ?? DefaultLanguageCode;
+        // Time always in Oslo timezone
+        var createdAt = transmission.CreatedAt
+            .ToLocalTime()
+            .ToString("dd.MM.yyyy / HH:mm", CultureInfo.InvariantCulture);
+        var sender = await GetSender(dialog.Party, cancellationToken);
+        // Return dialog.Org if AltinnOrgs is not responding
+        var receiver = orgs is null ? dialog.Org : GetReceiverName(orgs, dialog.Org, langCode);
+        // Extract last segment of instance GUID as short reference (12 hex chars)
+        var referenceNumber = instance.Id.Split("-")[^1];
+
+
+        var summary = await GetReceiptSummary(instance, application.VersionId, langCode, cancellationToken);
+        var receipt =
+            $"""
+             | | |
+             |---|---|
+             | **{GetFieldText(langCode, FieldTexts.DateSent)}:** | {createdAt} |
+             | **{GetFieldText(langCode, FieldTexts.Sender)}:** | {sender} |
+             | **{GetFieldText(langCode, FieldTexts.Receiver)}:** | {receiver} |
+             | **{GetFieldText(langCode, FieldTexts.ReferenceNumber)}:** | {referenceNumber} |
+
+             {summary}
+             """;
+        return new GetReceiptResponse.Success(receipt);
+    }
+
+    private static string GetReceiverName(AltinnOrgData orgs, string orgCode, string languageCode)
+    {
+        if (!orgs.Orgs.TryGetValue(orgCode, out var org))
+        {
+            return orgCode;
+        }
+
+        return org.Name.GetValueOrDefault(languageCode) ?? orgCode;
+    }
+
+    private async Task<string> GetSender(string partyUrn, CancellationToken cancellationToken)
+    {
+        var partyResponse = await _registerApi.GetPartiesByUrns(new PartyQueryRequest([partyUrn]), cancellationToken);
+        var partyIdentifier = partyResponse.Data.FirstOrDefault();
+        if (partyIdentifier is not null)
+        {
+            string prePendSender = String.Empty;
+            if (partyIdentifier.PersonIdentifier != null)
+            {
+                // Mask last 5 digits in the Norwegian national number
+                prePendSender = $"{partyIdentifier.PersonIdentifier[..6]}*****-";
+            }
+            else if (partyIdentifier.OrganizationIdentifier != null)
+            {
+                prePendSender = $"{partyIdentifier.OrganizationIdentifier}-";
+            }
+
+            return $"{prePendSender}{partyIdentifier.DisplayName}";
+        }
+        return string.Empty;
+    }
+
+    private async Task<string> GetReceiptSummary(Instance instance, string versionId, string languageCode,
+        CancellationToken cancellationToken)
+    {
+        var applicationTexts =
+            await _applicationRepository.GetApplicationTexts(instance.AppId, versionId, cancellationToken);
+
+        InstanceDerivedStatus status = InstanceDerivedStatus.ArchivedConfirmed;
+        var receiptSummaries = ApplicationTextParser
+            .GetLocalizationsFromApplicationTexts(InstanceReceiptSummaryKey,
+                instance, applicationTexts, status);
+
+        // Check if app have the "dp.receipt-transmission-summary" field set. If not return default text in correct language
+        return receiptSummaries
+            .Where(s => s.LanguageCode == languageCode)
+            .Select(s => s.Value)
+            .FirstOrDefault(GetFieldText(languageCode, FieldTexts.DefaultSummary));
+    }
+
+    private static string GetFieldText(string languageCode, FieldTexts fieldText)
+    {
+        var lang = languageCode switch
+        {
+            "en" => "en",
+            "nn" => "nn",
+            _ => "nb"
+        };
+
+        return (lang, fieldText) switch
+        {
+            ("en", FieldTexts.DateSent) => "Date sent",
+            ("en", FieldTexts.DefaultSummary) =>
+                "A mechanical check has been completed while filling in, but we reserve the right to detect errors during the processing of the case and that other documentation may be necessary. Please provide the reference number in case of any inquiries to the agency.",
+            ("en", FieldTexts.Receiver) => "Receiver",
+            ("en", FieldTexts.ReferenceNumber) => "Reference number",
+            ("en", FieldTexts.Sender) => "Sender",
+
+            ("nn", FieldTexts.DateSent) => "Dato sendt",
+            ("nn", FieldTexts.DefaultSummary) =>
+                "Det er gjennomført ein maskinell kontroll under utfylling, men vi tek atterhald om at det kan bli oppdaga feil under sakshandsaminga og at annan dokumentasjon kan vere naudsynt. Ver venleg oppgi referansenummer ved eventuelle førespurnadar til etaten.",
+            ("nn", FieldTexts.Receiver) => "Mottakar",
+            ("nn", FieldTexts.ReferenceNumber) => "Referansenummer",
+            ("nn", FieldTexts.Sender) => "Avsendar",
+
+            ("nb", FieldTexts.DateSent) => "Dato sendt",
+            ("nb", FieldTexts.DefaultSummary) =>
+                "Det er gjennomført en maskinell kontroll under utfylling, men vi tar forbehold om at det kan bli oppdaget feil under saksbehandlingen og at annen dokumentasjon kan være nødvendig. Vennligst oppgi referansenummer ved eventuelle henvendelser til etaten.",
+            ("nb", FieldTexts.Receiver) => "Mottaker",
+            ("nb", FieldTexts.ReferenceNumber) => "Referansenummer",
+            ("nb", FieldTexts.Sender) => "Avsender",
+            _ => throw new ArgumentOutOfRangeException(
+                $"Unsupported combination: {lang}, {fieldText}")
+        };
+    }
+
+    private enum FieldTexts
+    {
+        DateSent,
+        DefaultSummary,
+        Receiver,
+        ReferenceNumber,
+        Sender
+    }
+}
+
+public static partial class UrnParser
+{
+    [GeneratedRegex(@"^urn:altinn:integration:storage:(?<partyId>\d+)/(?<instanceGuid>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$", RegexOptions.IgnoreCase)]
+    private static partial Regex StorageUrnRegex();
+
+    public static bool TryParseStorageUrn(string? urn, out string partyId, out Guid instanceGuid)
+    {
+        partyId = String.Empty;
+        instanceGuid = Guid.Empty;
+
+        if (string.IsNullOrWhiteSpace(urn))
+            return false;
+
+        var match = StorageUrnRegex().Match(urn);
+        if (!match.Success)
+            return false;
+
+        partyId = match.Groups["partyId"].Value;
+
+        return Guid.TryParse(match.Groups["instanceGuid"].Value, out instanceGuid);
+    }
+}

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/InstanceReceipt.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/InstanceReceipt.cs
@@ -23,12 +23,13 @@ public abstract record GetReceiptResponse
     public sealed record InvalidLanguageCode : GetReceiptResponse;
 }
 
-internal sealed class InstanceReceipt(
+internal sealed partial class InstanceReceipt(
     IStorageApi storageApi,
     IApplicationRepository applicationRepository,
     IDialogportenApi dialogportenApi,
     IAltinnOrgs altinnOrgs,
-    IRegisterApi registerApi
+    IRegisterApi registerApi,
+    ILogger<InstanceReceipt> logger
     )
 {
     private readonly IStorageApi _storageApi = storageApi ?? throw new ArgumentNullException(nameof(storageApi));
@@ -36,11 +37,15 @@ internal sealed class InstanceReceipt(
     private readonly IDialogportenApi _dialogportenApi = dialogportenApi ?? throw new ArgumentNullException(nameof(dialogportenApi));
     private readonly IAltinnOrgs _altinnOrgs = altinnOrgs ?? throw new ArgumentNullException(nameof(altinnOrgs));
     private readonly IRegisterApi _registerApi = registerApi ?? throw new ArgumentNullException(nameof(registerApi));
+    private readonly ILogger<InstanceReceipt> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
     private const string DefaultLanguageCode = "nb";
     private const string InstanceReceiptSummaryKey = "receipt-transmission-summary";
 
     private static readonly List<string> LanguageCodes = ["nb", "nn", "en"];
+
+    [LoggerMessage(LogLevel.Error, "Unhandled error occured: {Message}")]
+    private partial void LogReceiptError(string message);
 
     public static string GetSupportedLanguageCodes() => string.Join(", ", LanguageCodes);
 
@@ -53,7 +58,10 @@ internal sealed class InstanceReceipt(
         if (dialog is null)
             return new GetReceiptResponse.NotFound();
 
-        if (!TryParseStorageUrn(dialog.ServiceOwnerContext?.ServiceOwnerLabels.FirstOrDefault()?.Value,
+        if (dialog.ServiceOwnerContext?.ServiceOwnerLabels.Count != 1)
+            throw new InvalidOperationException("ServiceOwnerContext should contain only one ServiceOwnerLabel");
+
+        if (!TryParseStorageUrn(dialog.ServiceOwnerContext.ServiceOwnerLabels[0].Value,
                 out string? partyId, out var instanceGuid))
             return new GetReceiptResponse.NotFound();
 
@@ -64,7 +72,10 @@ internal sealed class InstanceReceipt(
 
         var application = await _applicationRepository.GetApplication(instance.AppId, cancellationToken);
         if (application is null)
+        {
+            LogReceiptError($"Application {instance.AppId} does not exist");
             return new GetReceiptResponse.NotFound();
+        }
 
         var transmission = dialog.Transmissions.FirstOrDefault(x => x.Id == request.TransmissionId);
         if (transmission is null)
@@ -87,9 +98,8 @@ internal sealed class InstanceReceipt(
         var summary = await GetReceiptSummary(instance, application.VersionId, langCode, cancellationToken);
         var receipt =
             $"""
-             | | |
-             |---|---|
-             | **{GetFieldText(langCode, FieldTexts.DateSent)}:** | {createdAt} |
+             | **{GetFieldText(langCode, FieldTexts.DateSent)}:** | **{createdAt}** |
+             |:-|:-|
              | **{GetFieldText(langCode, FieldTexts.Sender)}:** | {sender} |
              | **{GetFieldText(langCode, FieldTexts.Receiver)}:** | {receiver} |
              | **{GetFieldText(langCode, FieldTexts.ReferenceNumber)}:** | {referenceNumber} |

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
@@ -350,6 +350,10 @@ internal sealed class StorageDialogportenDataMerger
             // so we take all attachments into a single transmission.
             var isA2 = IsA2Instance(dto.Instance);
             var transmissionId = activityDto.Id!.Value.ToVersion7(activityDto.CreatedAt!.Value);
+            var adapterBaseUri = _settings.DialogportenAdapter.Adapter.BaseUri
+                .ToString()
+                .TrimEnd('/');
+            var baseUrl = $"{adapterBaseUri}/api/v1/receipt/{dto.DialogId}/{transmissionId}";
             return new TransmissionDto
             {
                 Id = transmissionId,
@@ -366,7 +370,17 @@ internal sealed class StorageDialogportenDataMerger
                             new() { LanguageCode = "nn", Value = $"Innsending #{index + 1}" },
                             new() { LanguageCode = "en", Value = $"Submission #{index + 1}" }
                         ],
-                        MediaType = "text/plain"
+                        MediaType = MediaTypes.PlainText
+                    },
+                    ContentReference = new ContentValueDto
+                    {
+                        Value =
+                        [
+                            new() { LanguageCode = "nb", Value = $"{baseUrl}?lang=nb" },
+                            new() { LanguageCode = "nn", Value = $"{baseUrl}?lang=nn" },
+                            new() { LanguageCode = "en", Value = $"{baseUrl}?lang=en" }
+                        ],
+                        MediaType = MediaTypes.EmbeddableMarkdown
                     }
                 },
                 Attachments = userDataElements

--- a/src/Altinn.DialogportenAdapter.WebApi/Infrastructure/Dialogporten/DialogDto.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Infrastructure/Dialogporten/DialogDto.cs
@@ -17,6 +17,12 @@ public class DialogDto
     public Guid? Revision { get; set; }
 
     /// <summary>
+    /// The service owner code representing the organization (service owner) related to this dialog.
+    /// </summary>
+    /// <example>ske</example>
+    public string Org { get; set; } = null!;
+
+    /// <summary>
     /// The service identifier for the service that the dialog is related to in URN-format.
     /// This corresponds to a resource in the Altinn Resource Registry, which the authenticated organization
     /// must own, i.e., be listed as the "competent authority" in the Resource Registry entry.

--- a/src/Altinn.DialogportenAdapter.WebApi/Infrastructure/Register/IAltinnOrgs.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Infrastructure/Register/IAltinnOrgs.cs
@@ -1,0 +1,45 @@
+using Altinn.DialogportenAdapter.WebApi.Common;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Options;
+using ZiggyCreatures.Caching.Fusion;
+
+
+namespace Altinn.DialogportenAdapter.WebApi.Infrastructure.Register;
+
+public record Org(
+    [property: JsonPropertyName("name")] Dictionary<string, string> Name,
+    [property: JsonPropertyName("orgnr")] string OrgNr,
+    [property: JsonPropertyName("environments")] List<string> Environments,
+    [property: JsonPropertyName("logo")] string? Logo,
+    [property: JsonPropertyName("emblem")] string? Emblem,
+    [property: JsonPropertyName("homepage")] string? HomePage,
+    [property: JsonPropertyName("contact")] OrgContact? Contact = null);
+
+public record OrgContact(
+    [property: JsonPropertyName("phone")] string? Phone,
+    [property: JsonPropertyName("url")] string? Url);
+
+public record AltinnOrgData(
+    [property: JsonPropertyName("orgs")] Dictionary<string, Org> Orgs);
+
+internal interface IAltinnOrgs
+{
+    Task<AltinnOrgData?> GetAltinnOrgs(CancellationToken cancellationToken);
+}
+
+internal sealed class AltinnOrgs(IFusionCache cache, IHttpClientFactory clientFactory, IOptionsSnapshot<Settings> settings) : IAltinnOrgs
+{
+    private readonly IHttpClientFactory _clientFactory = clientFactory ?? throw new ArgumentNullException(nameof(clientFactory));
+    private readonly IFusionCache _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+    private readonly Settings _settings = settings.Value ?? throw new ArgumentNullException(nameof(settings));
+
+    public Task<AltinnOrgData?> GetAltinnOrgs(CancellationToken cancellationToken) =>
+        _cache.GetOrSetAsync(
+            key: nameof(AltinnOrgData),
+            factory: FetchAltinnOrgData,
+            token: cancellationToken).AsTask();
+
+    private async Task<AltinnOrgData?> FetchAltinnOrgData(CancellationToken ct) =>
+        await _clientFactory.CreateClient(Constants.AltinnOrgsClient)
+            .GetFromJsonAsync<AltinnOrgData>(_settings.DialogportenAdapter.Altinn.AltinnOrgs, ct);
+}

--- a/src/Altinn.DialogportenAdapter.WebApi/Infrastructure/Register/IAltinnOrgs.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Infrastructure/Register/IAltinnOrgs.cs
@@ -27,17 +27,34 @@ internal interface IAltinnOrgs
     Task<AltinnOrgData?> GetAltinnOrgs(CancellationToken cancellationToken);
 }
 
-internal sealed class AltinnOrgs(IFusionCache cache, IHttpClientFactory clientFactory, IOptionsSnapshot<Settings> settings) : IAltinnOrgs
+internal sealed partial class AltinnOrgs(
+    IFusionCache cache,
+    IHttpClientFactory clientFactory,
+    IOptionsSnapshot<Settings> settings,
+    ILogger<AltinnOrgs> logger) : IAltinnOrgs
 {
     private readonly IHttpClientFactory _clientFactory = clientFactory ?? throw new ArgumentNullException(nameof(clientFactory));
     private readonly IFusionCache _cache = cache ?? throw new ArgumentNullException(nameof(cache));
     private readonly Settings _settings = settings.Value ?? throw new ArgumentNullException(nameof(settings));
 
-    public Task<AltinnOrgData?> GetAltinnOrgs(CancellationToken cancellationToken) =>
-        _cache.GetOrSetAsync(
-            key: nameof(AltinnOrgData),
-            factory: FetchAltinnOrgData,
-            token: cancellationToken).AsTask();
+    [LoggerMessage(LogLevel.Warning, "Error occured: {errorMessage}")]
+    private partial void LogAltinnOrgsWarning(string errorMessage);
+
+    public async Task<AltinnOrgData?> GetAltinnOrgs(CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _cache.GetOrSetAsync(
+                key: nameof(AltinnOrgData),
+                factory: FetchAltinnOrgData,
+                token: cancellationToken).AsTask();
+        }
+        catch (Exception)
+        {
+            LogAltinnOrgsWarning("Failed to get AltinnOrgs from server. Using cached");
+            return null;
+        }
+    }
 
     private async Task<AltinnOrgData?> FetchAltinnOrgData(CancellationToken ct) =>
         await _clientFactory.CreateClient(Constants.AltinnOrgsClient)

--- a/src/Altinn.DialogportenAdapter.WebApi/Program.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Program.cs
@@ -242,6 +242,9 @@ static void BuildAndRun(string[] args)
         .AddTransient<ActivityDtoTransformer>()
         .AddTransient<FourHundredLoggingDelegatingHandler>()
         .AddTransient<InstanceService>()
+        .AddTransient<InstanceReceipt>()
+        .AddTransient<AuthorizationValidator>()
+        .AddTransient<IAltinnOrgs, AltinnOrgs>()
 
         // Http clients
         .AddRefitClient<IStorageApi>()
@@ -362,6 +365,32 @@ static void BuildAndRun(string[] args)
             };
         })
         .AllowAnonymous(); // 👈 Dialog token is validated inside InstanceService
+
+    v1Route.MapGet("receipt/{dialogId:guid}/{transactionId:guid}", async (
+            [FromRoute] Guid dialogId,
+            [FromRoute] Guid transactionId,
+            [FromQuery(Name = "lang")] string? languageCode,
+            [FromHeader(Name = "Authorization")] string authorization,
+            [FromServices] InstanceReceipt service,
+            [FromServices] AuthorizationValidator validator,
+            CancellationToken cancellationToken) =>
+        {
+            if (!validator.ValidateDialogToken(authorization, dialogId, ["read"]))
+                return Results.Unauthorized();
+
+            var request = new GetReceiptDto(dialogId, transactionId, languageCode);
+            return await service.GetReceipt(request, cancellationToken) switch
+            {
+                GetReceiptResponse.Success success => Results.Text(success.Markdown, MediaTypes.Markdown),
+                GetReceiptResponse.NotFound => Results.NotFound(),
+                GetReceiptResponse.InvalidLanguageCode => Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["lang"] = [$"Expected one of these language codes: {InstanceReceipt.GetSupportedLanguageCodes()}"]
+                }),
+                _ => Results.InternalServerError()
+            };
+        })
+        .AllowAnonymous();
 
     app.Run();
 }

--- a/src/Altinn.DialogportenAdapter.WebApi/Settings.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Settings.cs
@@ -32,7 +32,7 @@ public sealed record AdapterFeatureFlagSettings(bool EnableSubmissionTransmissio
 
 public sealed record DialogportenSettings(Uri BaseUri);
 
-public sealed record AltinnPlatformSettings(Uri BaseUri, Uri InternalStorageEndpoint, Uri InternalRegisterEndpoint, string SubscriptionKey)
+public sealed record AltinnPlatformSettings(Uri BaseUri, Uri InternalStorageEndpoint, Uri InternalRegisterEndpoint, string SubscriptionKey, Uri AltinnOrgs)
 {
     public Uri GetAppUriForOrg(string org, string appId) => new($"{BaseUri.Scheme}://{org}.apps.{BaseUri.Host}/{appId}");
     public Uri GetPlatformUri() => new($"{BaseUri.Scheme}://platform.{BaseUri.Host}");

--- a/src/Altinn.DialogportenAdapter.WebApi/appsettings.json
+++ b/src/Altinn.DialogportenAdapter.WebApi/appsettings.json
@@ -19,7 +19,8 @@
       "BaseUri": "PopulateFromEnvironmentVariable",
       "InternalStorageEndpoint": "PopulateFromEnvironmentVariable",
       "InternalRegisterEndpoint": "PopulateFromEnvironmentVariable",
-      "SubscriptionKey": "PopulateFromEnvironmentVariable"
+      "SubscriptionKey": "PopulateFromEnvironmentVariable",
+      "AltinnOrgs":"https://altinncdn.no/orgs/altinn-orgs.json"
     },
     "Dialogporten": {
       "BaseUri": "PopulateFromEnvironmentVariable"

--- a/tests/Altinn.DialogportenAdapter.Unit.Tests/Common/AuthorizationValidatorTests.cs
+++ b/tests/Altinn.DialogportenAdapter.Unit.Tests/Common/AuthorizationValidatorTests.cs
@@ -1,0 +1,72 @@
+using System.Security.Claims;
+using Altinn.ApiClients.Dialogporten;
+using Altinn.DialogportenAdapter.WebApi.Common;
+
+namespace Altinn.DialogportenAdapter.Unit.Tests.Common;
+
+public class AuthorizationValidatorTests
+{
+    [Fact]
+    public void Ctor_NullDialogTokenValidator_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new AuthorizationValidator(null!));
+        Assert.Equal("dialogTokenValidator", exception.ParamName);
+    }
+
+    [Fact]
+    public void ValidateDialogToken_WithBearerPrefix_StripsPrefixAndForwardsArguments()
+    {
+        var dialogId = Guid.NewGuid();
+        var actions = new[] { "read" };
+        var inner = new CapturingDialogTokenValidator(new ValidationResultStub(true));
+        var sut = new AuthorizationValidator(inner);
+        var result = sut.ValidateDialogToken("Bearer my-token".AsSpan(), dialogId, actions);
+
+        Assert.True(result);
+        Assert.Equal("my-token", inner.CapturedToken);
+        Assert.Equal(dialogId, inner.CapturedDialogId);
+        Assert.Equal(actions, inner.CapturedActions);
+    }
+
+    [Fact]
+    public void ValidateDialogToken_WithoutPrefix_PassesTokenAsIs()
+    {
+        var dialogId = Guid.NewGuid();
+        var actions = new[] { "delete" };
+        var inner = new CapturingDialogTokenValidator(new ValidationResultStub(false));
+        var sut = new AuthorizationValidator(inner);
+
+        var result = sut.ValidateDialogToken("raw-token".AsSpan(), dialogId, actions);
+
+        Assert.False(result);
+        Assert.Equal("raw-token", inner.CapturedToken);
+        Assert.Equal(dialogId, inner.CapturedDialogId);
+        Assert.Equal(actions, inner.CapturedActions);
+    }
+
+    private sealed class CapturingDialogTokenValidator(IValidationResult result) : IDialogTokenValidator
+    {
+        public string? CapturedToken { get; private set; }
+        public Guid? CapturedDialogId { get; private set; }
+        public string[] CapturedActions { get; private set; } = [];
+
+        public IValidationResult Validate(
+            ReadOnlySpan<char> token,
+            Guid? dialogId = null,
+            string[]? requiredActions = null,
+            DialogTokenValidationParameters? options = null)
+        {
+            CapturedToken = token.ToString();
+            CapturedDialogId = dialogId;
+            CapturedActions = requiredActions ?? [];
+            return result;
+        }
+    }
+
+    private sealed class ValidationResultStub(bool isValid) : IValidationResult
+    {
+        public bool IsValid { get; } = isValid;
+        public Dictionary<string, List<string>> Errors { get; } = [];
+        public ClaimsPrincipal? ClaimsPrincipal { get; } = null!;
+    }
+}

--- a/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/InstanceReceiptTests.cs
+++ b/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/InstanceReceiptTests.cs
@@ -1,0 +1,364 @@
+using System.Net;
+using Altinn.DialogportenAdapter.Unit.Tests.Common.Builder;
+using Altinn.DialogportenAdapter.WebApi.Features.Command.Sync;
+using Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
+using Altinn.DialogportenAdapter.WebApi.Infrastructure.Register;
+using Altinn.DialogportenAdapter.WebApi.Infrastructure.Storage;
+using Altinn.Platform.Storage.Interface.Models;
+using NSubstitute;
+using Refit;
+
+namespace Altinn.DialogportenAdapter.Unit.Tests.Features.Command.Sync;
+
+public class InstanceReceiptTests
+{
+    private static readonly RefitSettings RefitSettings = new();
+
+    [Fact]
+    public async Task GetReceipt_InvalidLanguageCode_ReturnsInvalidLanguageCode()
+    {
+        var (sut, _, _, _, _, _) = CreateSut();
+
+        var result = await sut.GetReceipt(
+            new GetReceiptDto(Guid.NewGuid(), Guid.NewGuid(), "de"),
+            CancellationToken.None);
+
+        Assert.IsType<GetReceiptResponse.InvalidLanguageCode>(result);
+    }
+
+    [Fact]
+    public async Task GetReceipt_DialogNotFound_ReturnsNotFound()
+    {
+        var dialogApi = Substitute.For<IDialogportenApi>();
+        dialogApi.Get(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IApiResponse<DialogDto>>(ApiNotFound<DialogDto>()));
+
+        var (sut, _, _, _, _, _) = CreateSut(dialogApi: dialogApi);
+
+        var result = await sut.GetReceipt(
+            new GetReceiptDto(Guid.NewGuid(), Guid.NewGuid(), "nb"),
+            CancellationToken.None);
+
+        Assert.IsType<GetReceiptResponse.NotFound>(result);
+    }
+
+    [Fact]
+    public async Task GetReceipt_InvalidStorageUrn_ReturnsNotFound()
+    {
+        var data = CreateHappyPathData();
+        data.Dialog.ServiceOwnerContext = new ServiceOwnerContext
+        {
+            ServiceOwnerLabels = [new ServiceOwnerLabel { Value = "not-a-storage-urn" }]
+        };
+
+        var (sut, _, _, _, _, _) = CreateSutFromData(data);
+
+        var result = await sut.GetReceipt(
+            new GetReceiptDto(data.DialogId, data.TransmissionId, "nb"),
+            CancellationToken.None);
+
+        Assert.IsType<GetReceiptResponse.NotFound>(result);
+    }
+
+    [Fact]
+    public async Task GetReceipt_InstanceNotFound_ReturnsNotFound()
+    {
+        var data = CreateHappyPathData();
+        var (sut, storageApi, _, _, _, _) = CreateSutFromData(data);
+        storageApi.GetInstance(data.PartyId, data.InstanceGuid, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IApiResponse<Instance>>(
+                ApiNotFound<Instance>()));
+
+        var result = await sut.GetReceipt(
+            new GetReceiptDto(data.DialogId, data.TransmissionId, "nb"),
+            CancellationToken.None);
+
+        Assert.IsType<GetReceiptResponse.NotFound>(result);
+    }
+
+    [Fact]
+    public async Task GetReceipt_ApplicationNotFound_ReturnsNotFound()
+    {
+        var data = CreateHappyPathData();
+        var (sut, _, applicationRepository, _, _, _) = CreateSutFromData(data);
+        applicationRepository.GetApplication(data.Instance.AppId, Arg.Any<CancellationToken>())
+            .Returns((Application?)null);
+
+        var result = await sut.GetReceipt(
+            new GetReceiptDto(data.DialogId, data.TransmissionId, "nb"),
+            CancellationToken.None);
+
+        Assert.IsType<GetReceiptResponse.NotFound>(result);
+    }
+
+    [Fact]
+    public async Task GetReceipt_TransmissionNotFound_ReturnsNotFound()
+    {
+        var data = CreateHappyPathData();
+        var missingTransmissionId = Guid.NewGuid();
+        var (sut, _, _, _, _, _) = CreateSutFromData(data);
+
+        var result = await sut.GetReceipt(
+            new GetReceiptDto(data.DialogId, missingTransmissionId, "nb"),
+            CancellationToken.None);
+
+        Assert.IsType<GetReceiptResponse.NotFound>(result);
+    }
+
+    [Fact]
+    public async Task GetReceipt_AltinnOrgsNotFound_ReturnsMarkDownWithOrg()
+    {
+        var data = CreateHappyPathData();
+        var (sut, _, _, _, altinnOrgs, _) = CreateSutFromData(data);
+        altinnOrgs.GetAltinnOrgs(Arg.Any<CancellationToken>())
+            .Returns((AltinnOrgData?)null);
+
+        var result = await sut.GetReceipt(
+            new GetReceiptDto(data.DialogId, data.TransmissionId, "nb"),
+            CancellationToken.None);
+
+        var success = Assert.IsType<GetReceiptResponse.Success>(result);
+        Assert.Contains("Dato sendt", success.Markdown);
+        Assert.Contains("123456*****-Ola Nordmann", success.Markdown);
+        Assert.Contains("digdir", success.Markdown);
+        Assert.Contains("Referansenummer", success.Markdown);
+        Assert.Contains("123456789abc", success.Markdown);
+    }
+
+    [Fact]
+    public async Task GetReceipt_HappyPath_ReturnsMarkdownNb()
+    {
+        var data = CreateHappyPathData();
+        var (sut, _, _, _, _, _) = CreateSutFromData(data);
+
+        var result = await sut.GetReceipt(
+            new GetReceiptDto(data.DialogId, data.TransmissionId, "nb"),
+            CancellationToken.None);
+
+        var success = Assert.IsType<GetReceiptResponse.Success>(result);
+        Assert.Contains("Dato sendt", success.Markdown);
+        Assert.Contains("Avsender:", success.Markdown);
+        Assert.Contains("123456*****-Ola Nordmann", success.Markdown);
+        Assert.Contains("Mottaker", success.Markdown);
+        Assert.Contains("Digitaliseringsdirektoratet", success.Markdown);
+        Assert.Contains("Referansenummer", success.Markdown);
+        Assert.Contains("123456789abc", success.Markdown);
+        Assert.Contains("Det er gjennomført en maskinell kontroll under utfylling", success.Markdown);
+    }
+
+    [Fact]
+    public async Task GetReceipt_HappyPath_ReturnsMarkdownNn()
+    {
+        var data = CreateHappyPathData();
+        var (sut, _, _, _, _, _) = CreateSutFromData(data);
+
+        var result = await sut.GetReceipt(
+            new GetReceiptDto(data.DialogId, data.TransmissionId, "nn"),
+            CancellationToken.None);
+
+        var success = Assert.IsType<GetReceiptResponse.Success>(result);
+        Assert.Contains("Dato sendt", success.Markdown);
+        Assert.Contains("Avsendar:", success.Markdown);
+        Assert.Contains("123456*****-Ola Nordmann", success.Markdown);
+        Assert.Contains("Mottakar", success.Markdown);
+        Assert.Contains("Digitaliseringsdirektoratet", success.Markdown);
+        Assert.Contains("Referansenummer", success.Markdown);
+        Assert.Contains("123456789abc", success.Markdown);
+        Assert.Contains("Det er gjennomført ein maskinell kontroll under utfylling", success.Markdown);
+    }
+
+    [Fact]
+    public async Task GetReceipt_HappyPath_ReturnsMarkdownEn()
+    {
+        var data = CreateHappyPathData();
+        var (sut, _, _, _, _, _) = CreateSutFromData(data);
+
+        var result = await sut.GetReceipt(
+            new GetReceiptDto(data.DialogId, data.TransmissionId, "en"),
+            CancellationToken.None);
+
+        var success = Assert.IsType<GetReceiptResponse.Success>(result);
+        Assert.Contains("Date sent", success.Markdown);
+        Assert.Contains("Sender:", success.Markdown);
+        Assert.Contains("123456*****-Ola Nordmann", success.Markdown);
+        Assert.Contains("Receiver", success.Markdown);
+        Assert.Contains("Norwegian Digitalisation Agency", success.Markdown);
+        Assert.Contains("Reference number", success.Markdown);
+        Assert.Contains("123456789abc", success.Markdown);
+        Assert.Contains("A mechanical check has been completed while filling in", success.Markdown);
+    }
+
+    private static (
+        InstanceReceipt Sut,
+        IStorageApi StorageApi,
+        IApplicationRepository ApplicationRepository,
+        IDialogportenApi DialogportenApi,
+        IAltinnOrgs AltinnOrgs,
+        IRegisterApi RegisterApi)
+        CreateSut(
+            IStorageApi? storageApi = null,
+            IApplicationRepository? applicationRepository = null,
+            IDialogportenApi? dialogApi = null,
+            IAltinnOrgs? altinnOrgs = null,
+            IRegisterApi? registerApi = null)
+    {
+        storageApi ??= Substitute.For<IStorageApi>();
+        applicationRepository ??= Substitute.For<IApplicationRepository>();
+        dialogApi ??= Substitute.For<IDialogportenApi>();
+        altinnOrgs ??= Substitute.For<IAltinnOrgs>();
+        registerApi ??= Substitute.For<IRegisterApi>();
+
+        return (
+            new InstanceReceipt(storageApi, applicationRepository, dialogApi, altinnOrgs, registerApi),
+            storageApi,
+            applicationRepository,
+            dialogApi,
+            altinnOrgs,
+            registerApi
+        );
+    }
+
+    private static (
+        InstanceReceipt Sut,
+        IStorageApi StorageApi,
+        IApplicationRepository ApplicationRepository,
+        IDialogportenApi DialogportenApi,
+        IAltinnOrgs AltinnOrgs,
+        IRegisterApi RegisterApi)
+        CreateSutFromData(
+            HappyPathData data,
+            IStorageApi? storageApi = null,
+            IApplicationRepository? applicationRepository = null,
+            IDialogportenApi? dialogApi = null,
+            IAltinnOrgs? altinnOrgs = null,
+            IRegisterApi? registerApi = null)
+    {
+        var created = CreateSut(storageApi, applicationRepository, dialogApi, altinnOrgs, registerApi);
+
+        created.DialogportenApi.Get(data.DialogId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IApiResponse<DialogDto>>(ApiOk(data.Dialog)));
+
+        created.StorageApi.GetInstance(data.PartyId, data.InstanceGuid, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IApiResponse<Instance>>(ApiOk(data.Instance)));
+
+        created.ApplicationRepository.GetApplication(data.Instance.AppId, Arg.Any<CancellationToken>())
+            .Returns(data.Application);
+
+        created.ApplicationRepository.GetApplicationTexts(data.Instance.AppId, data.Application.VersionId, Arg.Any<CancellationToken>())
+            .Returns(new ApplicationTexts { Translations = [] });
+
+        created.AltinnOrgs.GetAltinnOrgs(Arg.Any<CancellationToken>())
+            .Returns(data.Orgs);
+
+        created.RegisterApi.GetPartiesByUrns(Arg.Any<PartyQueryRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new PartyQueryResponse(
+                [
+                    new PartyIdentifier(
+                        PartyId: 1,
+                        PartyType: "Person",
+                        DisplayName: "Ola Nordmann",
+                        ExternalUrn: null,
+                        PersonIdentifier: "12345678910",
+                        OrganizationIdentifier: null)
+                ]));
+
+        return created;
+    }
+
+    private static HappyPathData CreateHappyPathData()
+    {
+        var dialogId = Guid.Parse("0195a56f-87af-7d13-8df5-7559f4f9d8c3");
+        var transmissionId = Guid.Parse("0195a56f-912b-7f7e-9c0d-3514fcfc935b");
+        var instanceGuid = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-123456789abc");
+        const string partyId = "512345";
+
+        var dialog = new DialogDto
+        {
+            Id = dialogId,
+            Org = "digdir",
+            Party = "urn:altinn:person:identifier-no:12345678910",
+            ServiceResource = "urn:altinn:resource:test-resource",
+            Content = new ContentDto
+            {
+                Title = new ContentValueDto(),
+                Summary = new ContentValueDto()
+            },
+            ServiceOwnerContext = new ServiceOwnerContext
+            {
+                ServiceOwnerLabels =
+                [
+                    new ServiceOwnerLabel
+                    {
+                        Value = $"urn:altinn:integration:storage:{partyId}/{instanceGuid:D}"
+                    }
+                ]
+            },
+            Transmissions =
+            [
+                new TransmissionDto
+                {
+                    Id = transmissionId,
+                    CreatedAt = new DateTimeOffset(2026, 3, 20, 10, 0, 0, TimeSpan.Zero),
+                    Sender = new ActorDto { ActorType = ActorType.PartyRepresentative, ActorName = "Unused" },
+                    Content = new TransmissionContentDto
+                    {
+                        Title = new ContentValueDto(),
+                        Summary = new ContentValueDto()
+                    }
+                }
+            ]
+        };
+
+        var instance = AltinnInstanceBuilder.NewArchivedAltinnInstance()
+            .WithAppId("ttd/app")
+            .WithId($"512345/{instanceGuid:D}")
+            .Build();
+
+        var application = AltinnApplicationBuilder.NewDefaultAltinnApplication()
+            .WithVersionId("1.0")
+            .Build();
+
+        var orgs = new AltinnOrgData(new Dictionary<string, Org>
+        {
+            ["digdir"] = new(
+                Name: new Dictionary<string, string>
+                {
+                    ["nb"] = "Digitaliseringsdirektoratet",
+                    ["nn"] = "Digitaliseringsdirektoratet",
+                    ["en"] = "Norwegian Digitalisation Agency"
+                },
+                OrgNr: "991825827",
+                Environments: ["tt02", "production"],
+                Logo: "logo",
+                Emblem: "emblem",
+                HomePage: "https://www.digdir.no",
+                Contact: null)
+        });
+
+        return new HappyPathData(dialogId, transmissionId, partyId, instanceGuid, dialog, instance, application, orgs);
+    }
+
+    private static ApiResponse<T> ApiOk<T>(T content) =>
+        new ApiResponse<T>(
+            response: new HttpResponseMessage(HttpStatusCode.OK),
+            content: content,
+            settings: RefitSettings,
+            error: null);
+
+    private static ApiResponse<T> ApiNotFound<T>() =>
+        new ApiResponse<T>(
+            response: new HttpResponseMessage(HttpStatusCode.NotFound),
+            content: default,
+            settings: RefitSettings,
+            error: null);
+
+    private sealed record HappyPathData(
+        Guid DialogId,
+        Guid TransmissionId,
+        string PartyId,
+        Guid InstanceGuid,
+        DialogDto Dialog,
+        Instance Instance,
+        Application Application,
+        AltinnOrgData Orgs);
+}

--- a/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/InstanceReceiptTests.cs
+++ b/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/InstanceReceiptTests.cs
@@ -5,6 +5,7 @@ using Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Register;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Storage;
 using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Refit;
 
@@ -208,8 +209,10 @@ public class InstanceReceiptTests
         altinnOrgs ??= Substitute.For<IAltinnOrgs>();
         registerApi ??= Substitute.For<IRegisterApi>();
 
+        ILogger<InstanceReceipt> logger = Substitute.For<ILogger<InstanceReceipt>>();
+
         return (
-            new InstanceReceipt(storageApi, applicationRepository, dialogApi, altinnOrgs, registerApi),
+            new InstanceReceipt(storageApi, applicationRepository, dialogApi, altinnOrgs, registerApi, logger),
             storageApi,
             applicationRepository,
             dialogApi,

--- a/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/StorageDialogportenDataMergerTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/StorageDialogportenDataMergerTest.cs
@@ -40,7 +40,8 @@ public class StorageDialogportenDataMergerTest
                     BaseUri: new Uri("http://altinn.localhost/"),
                     InternalStorageEndpoint: new Uri("http://altinn.storage.localhost/"),
                     InternalRegisterEndpoint: new Uri("http://altinn.register.localhost/"),
-                    SubscriptionKey: "subscriptionKey"
+                    SubscriptionKey: "subscriptionKey",
+                    AltinnOrgs: new Uri("https://altinncdn.no/orgs/altinn-orgs.json")
                 ),
                 Dialogporten: new DialogportenSettings(BaseUri: new Uri("http://dialogporten.localhost/")),
                 Adapter: new AdapterSettings(
@@ -2161,7 +2162,28 @@ public class StorageDialogportenDataMergerTest
                             MediaType = MediaTypes.PlainText
                         },
                         Summary = null!,
-                        ContentReference = null
+                        ContentReference = new ContentValueDto
+                        {
+                            Value =  [
+                                new LocalizationDto
+                                {
+                                    LanguageCode = "nb",
+                                    Value = "http://adapter.localhost/api/v1/receipt/902de1ba-6919-4355-99ad-7ad279266a2f/00e46784-34c8-7fdf-a7ec-f85248d2293c?lang=nb"
+                                },
+                                new LocalizationDto
+                                {
+                                    LanguageCode = "nn",
+                                    Value = "http://adapter.localhost/api/v1/receipt/902de1ba-6919-4355-99ad-7ad279266a2f/00e46784-34c8-7fdf-a7ec-f85248d2293c?lang=nn"
+                                },
+                                new LocalizationDto
+                                {
+                                    LanguageCode = "en",
+                                    Value = "http://adapter.localhost/api/v1/receipt/902de1ba-6919-4355-99ad-7ad279266a2f/00e46784-34c8-7fdf-a7ec-f85248d2293c?lang=en"
+                                }
+                            ]
+                            ,
+                            MediaType = "application/vnd.dialogporten.frontchannelembed-url;type=text/markdown"
+                        }
                     },
                     Attachments =
                     [
@@ -2217,7 +2239,28 @@ public class StorageDialogportenDataMergerTest
                             MediaType = MediaTypes.PlainText
                         },
                         Summary = null!,
-                        ContentReference = null
+                        ContentReference = new ContentValueDto
+                        {
+                            Value =  [
+                                new LocalizationDto
+                                {
+                                    LanguageCode = "nb",
+                                    Value = "http://adapter.localhost/api/v1/receipt/902de1ba-6919-4355-99ad-7ad279266a2f/00ebbf35-60c8-7fdf-a7ec-f85248d2293c?lang=nb"
+                                },
+                                new LocalizationDto
+                                {
+                                    LanguageCode = "nn",
+                                    Value = "http://adapter.localhost/api/v1/receipt/902de1ba-6919-4355-99ad-7ad279266a2f/00ebbf35-60c8-7fdf-a7ec-f85248d2293c?lang=nn"
+                                },
+                                new LocalizationDto
+                                {
+                                    LanguageCode = "en",
+                                    Value = "http://adapter.localhost/api/v1/receipt/902de1ba-6919-4355-99ad-7ad279266a2f/00ebbf35-60c8-7fdf-a7ec-f85248d2293c?lang=en"
+                                }
+                            ]
+                            ,
+                            MediaType = "application/vnd.dialogporten.frontchannelembed-url;type=text/markdown"
+                        }
                     },
                     Attachments =
                     [

--- a/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/StorageDialogportenDataMergerUpdateTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/StorageDialogportenDataMergerUpdateTest.cs
@@ -39,7 +39,8 @@ public class StorageDialogportenDataMergerUpdateTest
                     BaseUri: new Uri("http://altinn.localhost/"),
                     InternalStorageEndpoint: new Uri("http://altinn.storage.localhost/"),
                     InternalRegisterEndpoint: new Uri("http://altinn.register.localhost/"),
-                    SubscriptionKey: "subscriptionKey"
+                    SubscriptionKey: "subscriptionKey",
+                    AltinnOrgs: new Uri("https://altinncdn.no/orgs/altinn-orgs.json")
                 ),
                 Dialogporten: new DialogportenSettings(BaseUri: new Uri("http://dialogporten.localhost/")),
                 Adapter: new AdapterSettings(
@@ -401,7 +402,28 @@ public class StorageDialogportenDataMergerUpdateTest
                             MediaType = "text/plain"
                         },
                         Summary = null!,
-                        ContentReference = null
+                        ContentReference = new ContentValueDto
+                        {
+                            Value =  [
+                                new LocalizationDto
+                                {
+                                    LanguageCode = "nb",
+                                    Value = "http://adapter.localhost/api/v1/receipt/902de1ba-6919-4355-99ad-7ad279266a2f/00e46784-34c8-7fbc-996e-9a05cd175766?lang=nb"
+                                },
+                                new LocalizationDto
+                                {
+                                    LanguageCode = "nn",
+                                    Value = "http://adapter.localhost/api/v1/receipt/902de1ba-6919-4355-99ad-7ad279266a2f/00e46784-34c8-7fbc-996e-9a05cd175766?lang=nn"
+                                },
+                                new LocalizationDto
+                                {
+                                    LanguageCode = "en",
+                                    Value = "http://adapter.localhost/api/v1/receipt/902de1ba-6919-4355-99ad-7ad279266a2f/00e46784-34c8-7fbc-996e-9a05cd175766?lang=en"
+                                }
+                            ]
+                            ,
+                            MediaType = "application/vnd.dialogporten.frontchannelembed-url;type=text/markdown"
+                        }
                     },
                     Attachments = []
                 },
@@ -631,7 +653,28 @@ public class StorageDialogportenDataMergerUpdateTest
                             MediaType = "text/plain"
                         },
                         Summary = null!,
-                        ContentReference = null
+                        ContentReference = new ContentValueDto
+                        {
+                            Value =  [
+                                new LocalizationDto
+                                {
+                                    LanguageCode = "nb",
+                                    Value = "http://adapter.localhost/api/v1/receipt/902de1ba-6919-4355-99ad-7ad279266a2f/00e46784-34c8-7f4d-bed1-d5417461bb53?lang=nb"
+                                },
+                                new LocalizationDto
+                                {
+                                    LanguageCode = "nn",
+                                    Value = "http://adapter.localhost/api/v1/receipt/902de1ba-6919-4355-99ad-7ad279266a2f/00e46784-34c8-7f4d-bed1-d5417461bb53?lang=nn"
+                                },
+                                new LocalizationDto
+                                {
+                                    LanguageCode = "en",
+                                    Value = "http://adapter.localhost/api/v1/receipt/902de1ba-6919-4355-99ad-7ad279266a2f/00e46784-34c8-7f4d-bed1-d5417461bb53?lang=en"
+                                }
+                            ]
+                            ,
+                            MediaType = "application/vnd.dialogporten.frontchannelembed-url;type=text/markdown"
+                        }
                     },
                     Attachments =
                     [

--- a/tests/Altinn.DialogportenAdapter.Unit.Tests/Infrastructure/Register/AltinnOrgsTests.cs
+++ b/tests/Altinn.DialogportenAdapter.Unit.Tests/Infrastructure/Register/AltinnOrgsTests.cs
@@ -1,0 +1,231 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using Altinn.ApiClients.Maskinporten.Config;
+using Altinn.DialogportenAdapter.WebApi;
+using AwesomeAssertions;
+using Altinn.DialogportenAdapter.WebApi.Common;
+using Altinn.DialogportenAdapter.WebApi.Infrastructure.Register;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Altinn.DialogportenAdapter.Unit.Tests.Infrastructure.Register;
+
+public class AltinnOrgsTests
+{
+    private readonly IOptionsSnapshot<Settings> _settings;
+
+    public AltinnOrgsTests()
+    {
+        _settings = Substitute.For<IOptionsSnapshot<Settings>>();
+        _settings.Value.Returns(new Settings
+        {
+            DialogportenAdapter = new DialogportenAdapterSettings(
+                Maskinporten: new MaskinportenSettings
+                {
+                },
+                Altinn: new AltinnPlatformSettings
+                (
+                    BaseUri: new Uri("http://altinn.localhost/"),
+                    InternalStorageEndpoint: new Uri("http://altinn.storage.localhost/"),
+                    InternalRegisterEndpoint: new Uri("http://altinn.register.localhost/"),
+                    SubscriptionKey: "subscriptionKey",
+                    AltinnOrgs: new Uri("https://altinncdn.no/orgs/altinn-orgs.json")
+                ),
+                Dialogporten: new DialogportenSettings(BaseUri: new Uri("http://dialogporten.localhost/")),
+                Adapter: new AdapterSettings(
+                    BaseUri: new Uri("http://adapter.localhost/"),
+                    FeatureFlag: null
+                ),
+                Authentication: new AuthenticationSettings(JwtBearerWellKnown: "http://well.known.localhost")
+            ),
+            WolverineSettings = new WolverineSettings("http://service.bus.localhost", null)
+        });
+    }
+
+    private const string JsonPayload = """
+       {
+         "orgs": {
+           "digdir": {
+             "name": {
+               "en": "Norwegian Digitalisation Agency",
+               "nb": "Digitaliseringsdirektoratet",
+               "nn": "Digitaliseringsdirektoratet"
+             },
+             "logo": "https://altinncdn.no/orgs/digdir/digdir.png",
+             "emblem": "https://altinncdn.no/orgs/digdir/digdir.svg",
+             "orgnr": "991825827",
+             "homepage": "https://www.digdir.no",
+             "environments": ["tt02", "production"],
+             "contact": {
+               "phone": "+4722451000",
+               "url": "https://www.digdir.no/digdir/kontakt-oss/943"
+             }
+           },
+           "brg": {
+             "name": {
+               "en": "Brønnøysund Register Centre",
+               "nb": "Brønnøysundregistrene",
+               "nn": "Brønnøysundregistera"
+             },
+             "logo": "https://altinncdn.no/orgs/brg/brreg.png",
+             "orgnr": "974760673",
+             "homepage": "https://www.brreg.no",
+             "environments": ["tt02", "production"]
+           }
+         }
+       }
+       """;
+
+    [Fact]
+    public async Task GetAltinnOrgs_CheckMapping()
+    {
+        var expected = new AltinnOrgData(
+            new Dictionary<string, Org>
+            {
+                ["digdir"] = new Org(
+                    Name: new Dictionary<string, string>
+                    {
+                        ["en"] = "Norwegian Digitalisation Agency",
+                        ["nb"] = "Digitaliseringsdirektoratet",
+                        ["nn"] = "Digitaliseringsdirektoratet"
+                    },
+                    OrgNr: "991825827",
+                    Environments: ["tt02", "production"],
+                    Logo: "https://altinncdn.no/orgs/digdir/digdir.png",
+                    Emblem: "https://altinncdn.no/orgs/digdir/digdir.svg",
+                    HomePage: "https://www.digdir.no",
+                    Contact: new OrgContact(
+                        Phone: "+4722451000",
+                        Url: "https://www.digdir.no/digdir/kontakt-oss/943"
+                    )
+                ),
+                ["brg"] = new Org(
+                    Name: new Dictionary<string, string>
+                    {
+                        ["en"] = "Brønnøysund Register Centre",
+                        ["nb"] = "Brønnøysundregistrene",
+                        ["nn"] = "Brønnøysundregistera"
+                    },
+                    OrgNr: "974760673",
+                    Environments: ["tt02", "production"],
+                    Logo: "https://altinncdn.no/orgs/brg/brreg.png",
+                    Emblem: null,
+                    HomePage: "https://www.brreg.no",
+                    Contact: null
+                )
+            }
+        );
+
+        var handler = new StubHttpMessageHandler((_, _) =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonPayload, Encoding.UTF8, "application/json")
+            });
+        var sut = CreateSut(handler);
+
+        var result = await sut.GetAltinnOrgs(CancellationToken.None);
+
+        result.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public async Task GetAltinnOrgs_TwoCalls_UsesCacheAndCallsHttpOnce()
+    {
+        var handler = new StubHttpMessageHandler((_, _) =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonPayload, Encoding.UTF8, "application/json")
+            });
+
+        var sut = CreateSut(handler);
+
+        var first = await sut.GetAltinnOrgs(CancellationToken.None);
+        var second = await sut.GetAltinnOrgs(CancellationToken.None);
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.Equal(1, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task GetAltinnOrgs_NullPayload_ReturnsNull()
+    {
+        var handler = new StubHttpMessageHandler((_, _) =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create<AltinnOrgData?>(null)
+            });
+
+        var sut = CreateSut(handler);
+
+        var result = await sut.GetAltinnOrgs(CancellationToken.None);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetAltinnOrgs_HttpFailure_ThrowsHttpRequestException()
+    {
+        var handler = new StubHttpMessageHandler((_, _) =>
+            new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+        var sut = CreateSut(handler);
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => sut.GetAltinnOrgs(CancellationToken.None));
+    }
+
+    [Fact]
+    public void GetAltinnOrgs_NullCache_ThrowsArgumentNullException()
+    {
+        var clientFactory = Substitute.For<IHttpClientFactory>();
+        var ex = Assert.Throws<ArgumentNullException>(()  => new AltinnOrgs(null!, clientFactory, _settings));
+        Assert.Equal("cache", ex.ParamName);
+    }
+
+    [Fact]
+    public void GetAltinnOrgs_NullClientFactory_ThrowsArgumentNullException()
+    {
+        var cache = new FusionCache(new FusionCacheOptions());
+        var ex = Assert.Throws<ArgumentNullException>(()  => new AltinnOrgs(cache, null!, _settings));
+        Assert.Equal("clientFactory", ex.ParamName);
+    }
+
+    [Fact]
+    public void GetAltinnOrgs_NullSetting_ThrowsArgumentNullException()
+    {
+        var emptySettings = Substitute.For<IOptionsSnapshot<Settings>>();
+        var cache = new FusionCache(new FusionCacheOptions());
+        var clientFactory = Substitute.For<IHttpClientFactory>();
+        var ex = Assert.Throws<ArgumentNullException>(()  => new AltinnOrgs(cache, clientFactory, emptySettings));
+        Assert.Equal("settings", ex.ParamName);
+    }
+
+    private AltinnOrgs CreateSut(StubHttpMessageHandler handler)
+    {
+        var httpClient = new HttpClient(handler);
+        var clientFactory = Substitute.For<IHttpClientFactory>();
+        clientFactory
+            .CreateClient(Constants.AltinnOrgsClient)
+            .Returns(httpClient);
+
+        return new AltinnOrgs(new FusionCache(new FusionCacheOptions()), clientFactory, _settings);
+    }
+
+    private sealed class StubHttpMessageHandler(
+        Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> handle)
+        : HttpMessageHandler
+    {
+        public int CallCount { get; private set; }
+        public Uri? LastRequestUri { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            CallCount++;
+            LastRequestUri = request.RequestUri;
+            var response = handle(request, cancellationToken);
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/tests/Altinn.DialogportenAdapter.Unit.Tests/Infrastructure/Register/AltinnOrgsTests.cs
+++ b/tests/Altinn.DialogportenAdapter.Unit.Tests/Infrastructure/Register/AltinnOrgsTests.cs
@@ -6,6 +6,7 @@ using Altinn.DialogportenAdapter.WebApi;
 using AwesomeAssertions;
 using Altinn.DialogportenAdapter.WebApi.Common;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Register;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using ZiggyCreatures.Caching.Fusion;
@@ -15,9 +16,11 @@ namespace Altinn.DialogportenAdapter.Unit.Tests.Infrastructure.Register;
 public class AltinnOrgsTests
 {
     private readonly IOptionsSnapshot<Settings> _settings;
+    private ILogger<AltinnOrgs> _logger;
 
     public AltinnOrgsTests()
     {
+        _logger = Substitute.For<ILogger<AltinnOrgs>>();
         _settings = Substitute.For<IOptionsSnapshot<Settings>>();
         _settings.Value.Returns(new Settings
         {
@@ -165,21 +168,23 @@ public class AltinnOrgsTests
     }
 
     [Fact]
-    public async Task GetAltinnOrgs_HttpFailure_ThrowsHttpRequestException()
+    public async Task GetAltinnOrgs_HttpFailure_CatchExceptionAndReturnsNull()
     {
         var handler = new StubHttpMessageHandler((_, _) =>
             new HttpResponseMessage(HttpStatusCode.InternalServerError));
 
         var sut = CreateSut(handler);
 
-        await Assert.ThrowsAsync<HttpRequestException>(() => sut.GetAltinnOrgs(CancellationToken.None));
+        var result = await sut.GetAltinnOrgs(CancellationToken.None);
+        Assert.Null(result);
     }
 
     [Fact]
     public void GetAltinnOrgs_NullCache_ThrowsArgumentNullException()
     {
         var clientFactory = Substitute.For<IHttpClientFactory>();
-        var ex = Assert.Throws<ArgumentNullException>(()  => new AltinnOrgs(null!, clientFactory, _settings));
+
+        var ex = Assert.Throws<ArgumentNullException>(()  => new AltinnOrgs(null!, clientFactory, _settings, _logger));
         Assert.Equal("cache", ex.ParamName);
     }
 
@@ -187,7 +192,7 @@ public class AltinnOrgsTests
     public void GetAltinnOrgs_NullClientFactory_ThrowsArgumentNullException()
     {
         var cache = new FusionCache(new FusionCacheOptions());
-        var ex = Assert.Throws<ArgumentNullException>(()  => new AltinnOrgs(cache, null!, _settings));
+        var ex = Assert.Throws<ArgumentNullException>(()  => new AltinnOrgs(cache, null!, _settings, _logger));
         Assert.Equal("clientFactory", ex.ParamName);
     }
 
@@ -197,7 +202,7 @@ public class AltinnOrgsTests
         var emptySettings = Substitute.For<IOptionsSnapshot<Settings>>();
         var cache = new FusionCache(new FusionCacheOptions());
         var clientFactory = Substitute.For<IHttpClientFactory>();
-        var ex = Assert.Throws<ArgumentNullException>(()  => new AltinnOrgs(cache, clientFactory, emptySettings));
+        var ex = Assert.Throws<ArgumentNullException>(()  => new AltinnOrgs(cache, clientFactory, emptySettings, _logger));
         Assert.Equal("settings", ex.ParamName);
     }
 
@@ -209,7 +214,7 @@ public class AltinnOrgsTests
             .CreateClient(Constants.AltinnOrgsClient)
             .Returns(httpClient);
 
-        return new AltinnOrgs(new FusionCache(new FusionCacheOptions()), clientFactory, _settings);
+        return new AltinnOrgs(new FusionCache(new FusionCacheOptions()), clientFactory, _settings, _logger);
     }
 
     private sealed class StubHttpMessageHandler(


### PR DESCRIPTION
## Description
When a dialog is in an archived state and we expect a receipt for what we have sendt in, the field ContentReference will be populated with FCE urls for the languages nb, nn and en. 

These urls lead back to an adapter endpoint which will generate a markdown that will be shown as the receipt. 

## Related Issue(s)
- https://github.com/Altinn/altinn-dialogporten-adapter/issues/150

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New API endpoint returns dialog receipts as localized Markdown (nb/nn/en) with date, sender, receiver and reference; validates language and authorization.

* **Chores**
  * Added cached organization lookup and new configuration entry for org data source.
  * Transmissions now include language-specific embed URLs for front-channel receipt content; receiver names support localization with fallbacks.

* **Tests**
  * Unit tests added/updated for org data fetching, caching, error cases, and content-reference behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

I think this is the best we can do with markdown. 
Alternative is to change to HTML to format better
<img width="988" height="354" alt="Skjermbilde 2026-04-01 kl  11 10 35" src="https://github.com/user-attachments/assets/f9979464-21d7-4c3c-a9c4-f74e5a589245" />
