### PR TITLE
Add explicit permissions to workflow files

### DIFF
--- a/.github/workflows/auto-add-items.yml
+++ b/.github/workflows/auto-add-items.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     types: [opened, reopened, labeled]
 
+permissions: {}
+
 jobs:
   add-to-project:
     name: Add issue to project

--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -9,10 +9,17 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened]
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   build-test-analyze:
     name: Build, test & analyze
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -14,9 +14,13 @@ on:
   schedule:
     - cron: '0 8 * * 1,4'
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build the Docker image


### PR DESCRIPTION
## Summary

Adds least-privilege `permissions` blocks to all three GitHub Actions workflow files, following the deny-all-at-top, grant-at-job-level pattern:

- **auto-add-items.yml**: Top-level `permissions: {}` (job uses a PAT, not GITHUB_TOKEN)
- **build-and-analyze.yml**: Top-level `permissions: {}` with job-level `contents: read`, `pull-requests: write`, `checks: write`
- **container-scan.yml**: Top-level `permissions: {}` with job-level `contents: read`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration and permissions settings for improved security controls across automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->