### PR TITLE
fix: bumping formsaved only on consecutive formsaved

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ActivityDtoTransformer.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ActivityDtoTransformer.cs
@@ -25,6 +25,7 @@ internal sealed class ActivityDtoTransformer
         var createdFound = false;
         var actorUrnByUserId = await LookupUsers(events.InstanceEvents, cancellationToken);
 
+        ActivityDto? previousActivity = null;
         foreach (var @event in events.InstanceEvents.OrderBy(x => x.Created))
         {
             if (!Enum.TryParse<InstanceEventType>(@event.EventType, ignoreCase: true, out var eventType))
@@ -66,17 +67,16 @@ internal sealed class ActivityDtoTransformer
             createdFound = createdFound || activityType == DialogActivityType.DialogCreated;
             
             // Only bump timestamp of Formsaved if the last activity is a FormSaved and the current event is also a FormSaved
-            var lastActivity = activities.LastOrDefault();
-            if (lastActivity?.Type == DialogActivityType.FormSaved && activityType == DialogActivityType.FormSaved)
+            if (previousActivity?.Type == DialogActivityType.FormSaved && activityType == DialogActivityType.FormSaved)
             {
                 if (GetPerformedBy(@event.User, instanceOwner, actorUrnByUserId).ActorId == activities.Last().PerformedBy.ActorId)
                 {
-                    lastActivity.CreatedAt = @event.Created;
+                    previousActivity.CreatedAt = @event.Created;
                     continue;
                 }
             }
-
-            activities.Add(new ActivityDto
+            
+            var activity = new ActivityDto
             {
                 Id = @event.Id!.Value.ToVersion7(@event.Created!.Value),
                 Type = activityType.Value,
@@ -85,7 +85,9 @@ internal sealed class ActivityDtoTransformer
                 Description = activityType == DialogActivityType.Information // Todo: This never happens. The Information type is never handled
                     ? [new LocalizationDto { LanguageCode = "nb", Value = eventType.ToString() }]
                     : []
-            });
+            };
+            previousActivity = activity;
+            activities.Add(activity);
         }
         return activities;
     }

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ActivityDtoTransformer.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ActivityDtoTransformer.cs
@@ -65,7 +65,7 @@ internal sealed class ActivityDtoTransformer
             }
             
             createdFound = createdFound || activityType == DialogActivityType.DialogCreated;
-            var performedBy = GetPerformedBy(@event.User, instanceOwner, actorUrnByUserId);
+            var performedBy = GetPerformedBy(@event.User, actorUrnByUserId);
             // Only bump timestamp of Formsaved if the last activity is a FormSaved and the current event is also a FormSaved
             if (previousActivity?.Type == DialogActivityType.FormSaved 
                 && activityType == DialogActivityType.FormSaved 
@@ -81,9 +81,7 @@ internal sealed class ActivityDtoTransformer
                 Type = activityType.Value,
                 CreatedAt = @event.Created,
                 PerformedBy = performedBy,
-                Description = activityType == DialogActivityType.Information // Todo: This never happens. The Information type is never handled
-                    ? [new LocalizationDto { LanguageCode = "nb", Value = eventType.ToString() }]
-                    : []
+                Description = []
             };
             previousActivity = activity;
             activities.Add(activity);
@@ -116,7 +114,7 @@ internal sealed class ActivityDtoTransformer
         return actorUrnByUserUrn.ToDictionary(x => int.Parse(x.Key, CultureInfo.InvariantCulture), x => x.Value);
     }
 
-    private static ActorDto GetPerformedBy(PlatformUser user, InstanceOwner instanceOwner, Dictionary<int, string> actorUrnByUserId)
+    private static ActorDto GetPerformedBy(PlatformUser user, Dictionary<int, string> actorUrnByUserId)
     {
         if (user.UserId.HasValue && actorUrnByUserId.TryGetValue(user.UserId.Value, out var actorUrn))
         {

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ActivityDtoTransformer.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ActivityDtoTransformer.cs
@@ -46,15 +46,30 @@ internal sealed class ActivityDtoTransformer
                 InstanceEventType.SentToPayment => DialogActivityType.SentToPayment,
                 InstanceEventType.SentToSendIn => DialogActivityType.SentToSendIn,
                 InstanceEventType.SentToFormFill => DialogActivityType.SentToFormFill,
+                InstanceEventType.Saved => DialogActivityType.FormSaved,
                 _ => (DialogActivityType?)null
             };
 
-            if (!activityType.HasValue)
+            if (activityType is null)
             {
                 continue;
             }
 
             createdFound = createdFound || activityType == DialogActivityType.DialogCreated;
+            
+            // Only bump timestamp of Formsaved if the last activity is a FormSaved and the current event is also a FormSaved
+            // We ignore "Saved" events from the service owner, as they are typically related to transformations performed by the app
+            // as a consequence of the instance being saved by the end user, and do not represent an explicit action performed by the service owner.
+            // These events are usually interleaved, breaking the collapsing of "Saved" events performed by the end user.
+            var lastActivity = activities.LastOrDefault();
+            if (lastActivity?.Type == DialogActivityType.FormSaved && activityType == DialogActivityType.FormSaved && string.IsNullOrWhiteSpace(@event.User.OrgId))
+            {
+                if (GetPerformedBy(@event.User, instanceOwner, actorUrnByUserId).ActorId == activities.Last().PerformedBy.ActorId)
+                {
+                    lastActivity.CreatedAt = @event.Created;
+                    continue;
+                }
+            }
 
             activities.Add(new ActivityDto
             {
@@ -63,38 +78,10 @@ internal sealed class ActivityDtoTransformer
                 CreatedAt = @event.Created,
                 PerformedBy = GetPerformedBy(@event.User, instanceOwner, actorUrnByUserId),
                 Description = activityType == DialogActivityType.Information // Todo: This never happens. The Information type is never handled
-                    ? [ new LocalizationDto { LanguageCode = "nb", Value = eventType.ToString() } ]
-                    : [ ]
+                    ? [new LocalizationDto { LanguageCode = "nb", Value = eventType.ToString() }]
+                    : []
             });
         }
-
-        var savedEvents = events.InstanceEvents
-            .OrderBy(x => x.Created)
-            .Where(x => StringComparer.OrdinalIgnoreCase.Equals(x.EventType, "Saved"))
-            // We ignore "Saved" events from the service owner, as they are typically related to transformations performed by the app
-            // as a consequence of the instance being saved by the end user, and do not represent an explicit action performed by the service owner.
-            // These events are usually interleaved, breaking the collapsing of "Saved" events performed by the end user.
-            .Where(x => string.IsNullOrWhiteSpace(x.User.OrgId))
-            .Aggregate((SavedActivities: new List<ActivityDto>(), PreviousActivity: (ActivityDto?)null), (state, @event) =>
-            {
-                var currentActor = GetPerformedBy(@event.User, instanceOwner, actorUrnByUserId);
-                if (IsPerformedBy(state.PreviousActivity, currentActor))
-                {
-                    state.PreviousActivity.CreatedAt = @event.Created;
-                    return state;
-                }
-
-                state.SavedActivities.Add(state.PreviousActivity = new ActivityDto
-                {
-                    Id = @event.Id!.Value.ToVersion7(@event.Created!.Value),
-                    Type = DialogActivityType.FormSaved,
-                    CreatedAt = @event.Created,
-                    PerformedBy = currentActor
-                });
-                return state;
-            }, state => state.SavedActivities);
-
-        activities.AddRange(savedEvents);
         return activities;
     }
 

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ActivityDtoTransformer.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ActivityDtoTransformer.cs
@@ -55,14 +55,19 @@ internal sealed class ActivityDtoTransformer
                 continue;
             }
 
-            createdFound = createdFound || activityType == DialogActivityType.DialogCreated;
-            
-            // Only bump timestamp of Formsaved if the last activity is a FormSaved and the current event is also a FormSaved
             // We ignore "Saved" events from the service owner, as they are typically related to transformations performed by the app
             // as a consequence of the instance being saved by the end user, and do not represent an explicit action performed by the service owner.
             // These events are usually interleaved, breaking the collapsing of "Saved" events performed by the end user.
+            if (activityType == DialogActivityType.FormSaved && !string.IsNullOrWhiteSpace(@event.User.OrgId))
+            {
+                continue;
+            }
+            
+            createdFound = createdFound || activityType == DialogActivityType.DialogCreated;
+            
+            // Only bump timestamp of Formsaved if the last activity is a FormSaved and the current event is also a FormSaved
             var lastActivity = activities.LastOrDefault();
-            if (lastActivity?.Type == DialogActivityType.FormSaved && activityType == DialogActivityType.FormSaved && string.IsNullOrWhiteSpace(@event.User.OrgId))
+            if (lastActivity?.Type == DialogActivityType.FormSaved && activityType == DialogActivityType.FormSaved)
             {
                 if (GetPerformedBy(@event.User, instanceOwner, actorUrnByUserId).ActorId == activities.Last().PerformedBy.ActorId)
                 {

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ActivityDtoTransformer.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ActivityDtoTransformer.cs
@@ -69,7 +69,7 @@ internal sealed class ActivityDtoTransformer
             // Only bump timestamp of Formsaved if the last activity is a FormSaved and the current event is also a FormSaved
             if (previousActivity?.Type == DialogActivityType.FormSaved 
                 && activityType == DialogActivityType.FormSaved 
-                && performedBy.ActorId == previousActivity.PerformedBy.ActorId)
+                && IsPerformedBy(previousActivity, performedBy))
             {
                 previousActivity.CreatedAt = @event.Created;
                 continue;

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ActivityDtoTransformer.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ActivityDtoTransformer.cs
@@ -69,7 +69,7 @@ internal sealed class ActivityDtoTransformer
             // Only bump timestamp of Formsaved if the last activity is a FormSaved and the current event is also a FormSaved
             if (previousActivity?.Type == DialogActivityType.FormSaved && activityType == DialogActivityType.FormSaved)
             {
-                if (performedBy.ActorId == activities.Last().PerformedBy.ActorId)
+                if (performedBy.ActorId == previousActivity.PerformedBy.ActorId)
                 {
                     previousActivity.CreatedAt = @event.Created;
                     continue;

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ActivityDtoTransformer.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ActivityDtoTransformer.cs
@@ -67,13 +67,12 @@ internal sealed class ActivityDtoTransformer
             createdFound = createdFound || activityType == DialogActivityType.DialogCreated;
             var performedBy = GetPerformedBy(@event.User, instanceOwner, actorUrnByUserId);
             // Only bump timestamp of Formsaved if the last activity is a FormSaved and the current event is also a FormSaved
-            if (previousActivity?.Type == DialogActivityType.FormSaved && activityType == DialogActivityType.FormSaved)
+            if (previousActivity?.Type == DialogActivityType.FormSaved 
+                && activityType == DialogActivityType.FormSaved 
+                && performedBy.ActorId == previousActivity.PerformedBy.ActorId)
             {
-                if (performedBy.ActorId == previousActivity.PerformedBy.ActorId)
-                {
-                    previousActivity.CreatedAt = @event.Created;
-                    continue;
-                }
+                previousActivity.CreatedAt = @event.Created;
+                continue;
             }
             
             var activity = new ActivityDto

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ActivityDtoTransformer.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ActivityDtoTransformer.cs
@@ -65,11 +65,11 @@ internal sealed class ActivityDtoTransformer
             }
             
             createdFound = createdFound || activityType == DialogActivityType.DialogCreated;
-            
+            var performedBy = GetPerformedBy(@event.User, instanceOwner, actorUrnByUserId);
             // Only bump timestamp of Formsaved if the last activity is a FormSaved and the current event is also a FormSaved
             if (previousActivity?.Type == DialogActivityType.FormSaved && activityType == DialogActivityType.FormSaved)
             {
-                if (GetPerformedBy(@event.User, instanceOwner, actorUrnByUserId).ActorId == activities.Last().PerformedBy.ActorId)
+                if (performedBy.ActorId == activities.Last().PerformedBy.ActorId)
                 {
                     previousActivity.CreatedAt = @event.Created;
                     continue;
@@ -81,7 +81,7 @@ internal sealed class ActivityDtoTransformer
                 Id = @event.Id!.Value.ToVersion7(@event.Created!.Value),
                 Type = activityType.Value,
                 CreatedAt = @event.Created,
-                PerformedBy = GetPerformedBy(@event.User, instanceOwner, actorUrnByUserId),
+                PerformedBy = performedBy,
                 Description = activityType == DialogActivityType.Information // Todo: This never happens. The Information type is never handled
                     ? [new LocalizationDto { LanguageCode = "nb", Value = eventType.ToString() }]
                     : []

--- a/src/Altinn.DialogportenAdapter.WebApi/HttpRequests/SyncByInstanceId.http
+++ b/src/Altinn.DialogportenAdapter.WebApi/HttpRequests/SyncByInstanceId.http
@@ -1,4 +1,4 @@
-@instanceId = 50135588/ae847e47-58e0-4532-8f7d-bf701c6e5e88
+@instanceId = 50996849/a75481c1-6af6-43c4-a4c5-aedee384892e
 
 ### Log into maskinporten
 // @no-log

--- a/src/Altinn.DialogportenAdapter.WebApi/HttpRequests/SyncByInstanceId.http
+++ b/src/Altinn.DialogportenAdapter.WebApi/HttpRequests/SyncByInstanceId.http
@@ -1,4 +1,4 @@
-@instanceId = 50996849/a75481c1-6af6-43c4-a4c5-aedee384892e
+@instanceId = 50135588/ae847e47-58e0-4532-8f7d-bf701c6e5e88
 
 ### Log into maskinporten
 // @no-log

--- a/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/ActivityDtoTransformerTests.cs
+++ b/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/ActivityDtoTransformerTests.cs
@@ -43,6 +43,50 @@ public class ActivityDtoTransformerTests
         Assert.Equal("urn:altinn:person:identifier-no:02027012345", savedActivities[1].PerformedBy.ActorId);
         Assert.Equal(new DateTimeOffset(t0.AddMinutes(5)), savedActivities[1].CreatedAt);
     }
+    
+    
+    [Fact]
+    public async Task GetActivities_SavedEvents_CollapsesPerUser_AndIgnoresServiceOwner_AndMaintainsOrder()
+    {
+        var registerRepository = new FakeRegisterRepository(new Dictionary<string, string>
+        {
+            ["1001"] = "urn:altinn:person:identifier-no:01017012345",
+            ["1002"] = "urn:altinn:person:identifier-no:02027012345"
+        });
+
+        var sut = new ActivityDtoTransformer(registerRepository);
+        var t0 = new DateTime(2026, 2, 9, 12, 0, 0, DateTimeKind.Utc);
+
+        var events = new InstanceEventList
+        {
+            InstanceEvents =
+            [
+                new InstanceEvent { Id = Guid.NewGuid(), Created = t0, EventType = "Saved", User = new PlatformUser { UserId = 1001 } },
+                new InstanceEvent { Id = Guid.NewGuid(), Created = t0.AddMinutes(1), EventType = "Saved", User = new PlatformUser { OrgId = "ttd" } },
+                new InstanceEvent { Id = Guid.NewGuid(), Created = t0.AddMinutes(2), EventType = "Saved", User = new PlatformUser { UserId = 1001 } },
+                new InstanceEvent { Id = Guid.NewGuid(), Created = t0.AddMinutes(3), EventType = "Saved", User = new PlatformUser { UserId = 1002 } },
+                new InstanceEvent { Id = Guid.NewGuid(), Created = t0.AddMinutes(4), EventType = "Saved", User = new PlatformUser { OrgId = "ttd" } },
+                new InstanceEvent { Id = Guid.NewGuid(), Created = t0.AddMinutes(5), EventType = "Submited", User = new PlatformUser { UserId = 1001 } },
+                new InstanceEvent { Id = Guid.NewGuid(), Created = t0.AddMinutes(6), EventType = "Saved", User = new PlatformUser { UserId = 1002 } }
+            ]
+        };
+
+        var activities = await sut.GetActivities(events, new InstanceOwner(), CancellationToken.None);
+        var savedActivities = activities.Where(x => x.Type == DialogActivityType.FormSaved).ToList();
+
+        Assert.Equal(4, activities.Count);
+        Assert.Equal(3, savedActivities.Count);
+
+        Assert.Equal("urn:altinn:person:identifier-no:01017012345", savedActivities[0].PerformedBy.ActorId);
+        Assert.Equal(new DateTimeOffset(t0.AddMinutes(2)), savedActivities[0].CreatedAt);
+
+        Assert.Equal("urn:altinn:person:identifier-no:02027012345", savedActivities[1].PerformedBy.ActorId);
+        Assert.Equal(new DateTimeOffset(t0.AddMinutes(3)), savedActivities[1].CreatedAt);
+        
+        
+        Assert.Equal("urn:altinn:person:identifier-no:02027012345", savedActivities[2].PerformedBy.ActorId);
+        Assert.Equal(new DateTimeOffset(t0.AddMinutes(6)), savedActivities[2].CreatedAt);
+    }
 
     private sealed class FakeRegisterRepository : IRegisterRepository
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Only bump formsaved timestamp on consecutive formsaved by the same user

## Related Issue(s)
- #231

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved processing of saved/form-saved events to collapse consecutive saves per user, ignore service-owner saves, and preserve original event ordering; descriptions default to empty lists.
* **Tests**
  * Added unit test verifying collapse behavior, ignore-of-service-owner saves, and preserved ordering for mixed event sequences.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-dialogporten-adapter/pull/230)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->