### PR TITLE
fix: Handle 404 for purge dialog

### DIFF
--- a/src/Altinn.DialogportenAdapter.EventSimulator/Altinn.DialogportenAdapter.EventSimulator.csproj
+++ b/src/Altinn.DialogportenAdapter.EventSimulator/Altinn.DialogportenAdapter.EventSimulator.csproj
@@ -5,7 +5,7 @@
       <PackageReference Include="Azure.Data.Tables" Version="12.11.0" />
       <PackageReference Include="Polly" Version="8.6.6" />
       <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
-      <PackageReference Include="Refit.HttpClientFactory" Version="10.1.6" />
+      <PackageReference Include="Refit.HttpClientFactory" Version="10.2.0" />
       <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="10.0.1" />
       <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
       <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />

--- a/src/Altinn.DialogportenAdapter.WebApi/Altinn.DialogportenAdapter.WebApi.csproj
+++ b/src/Altinn.DialogportenAdapter.WebApi/Altinn.DialogportenAdapter.WebApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <ItemGroup>
-        <PackageReference Include="Altinn.ApiClients.Dialogporten" Version="1.114.8" />
+        <PackageReference Include="Altinn.ApiClients.Dialogporten" Version="1.116.0" />
         <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="10.0.1" />
         <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
         <PackageReference Include="Altinn.Platform.Storage.Interface" Version="4.7.1" />
@@ -9,7 +9,7 @@
         <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.5.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
-        <PackageReference Include="Refit.HttpClientFactory" Version="10.1.6" />
+        <PackageReference Include="Refit.HttpClientFactory" Version="10.2.0" />
         <PackageReference Include="DeterministicGuids" Version="1.0.11" />
         <PackageReference Include="WolverineFx.AzureServiceBus" Version="5.39.0" />
         <PackageReference Include="ZiggyCreatures.FusionCache.Locking.AsyncKeyed" Version="2.6.0" />

--- a/src/Altinn.DialogportenAdapter.WebApi/Common/Exceptions/DialogNotFoundForPurge.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/Exceptions/DialogNotFoundForPurge.cs
@@ -1,4 +1,4 @@
 namespace Altinn.DialogportenAdapter.WebApi.Common.Exceptions;
 
-public class DialogNotFoundForPurgeException(Guid dialogId, Guid revision)
-    : Exception($"Can't purge dialog {dialogId} at revision {revision}: Dialog not found.");
+public class DialogNotFoundForPurgeException(Guid dialogId, Guid revision, string traceId)
+    : Exception($"Can't purge dialog {dialogId} at revision {revision}: Dialog not found. TraceId: {traceId}");

--- a/src/Altinn.DialogportenAdapter.WebApi/Common/Exceptions/DialogNotFoundForPurge.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/Exceptions/DialogNotFoundForPurge.cs
@@ -1,0 +1,4 @@
+namespace Altinn.DialogportenAdapter.WebApi.Common.Exceptions;
+
+public class DialogNotFoundForPurgeException(Guid dialogId, Guid revision)
+    : Exception($"Can't purge dialog {dialogId} at revision {revision}: Dialog not found.");

--- a/src/Altinn.DialogportenAdapter.WebApi/Common/Exceptions/DialogNotFoundForPurge.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/Exceptions/DialogNotFoundForPurge.cs
@@ -1,4 +1,0 @@
-namespace Altinn.DialogportenAdapter.WebApi.Common.Exceptions;
-
-public class DialogNotFoundForPurgeException(Guid dialogId, Guid revision)
-    : Exception($"Can't purge dialog {dialogId} at revision {revision}: Dialog not found.");

--- a/src/Altinn.DialogportenAdapter.WebApi/Common/Exceptions/PartyNotFoundException.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/Exceptions/PartyNotFoundException.cs
@@ -1,0 +1,3 @@
+namespace Altinn.DialogportenAdapter.WebApi.Common.Exceptions;
+
+public class PartyNotFoundException(string? partyId) : InvalidOperationException($"Party with id {partyId} not found");

--- a/src/Altinn.DialogportenAdapter.WebApi/Common/Exceptions/PartyNotFoundException.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/Exceptions/PartyNotFoundException.cs
@@ -1,3 +1,3 @@
-namespace Altinn.DialogportenAdapter.WebApi.Common;
+namespace Altinn.DialogportenAdapter.WebApi.Common.Exceptions;
 
 public class PartyNotFoundException(string? partyId) : InvalidOperationException($"Party with id {partyId} not found");

--- a/src/Altinn.DialogportenAdapter.WebApi/Common/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/Extensions/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Altinn.ApiClients.Dialogporten;
 using Altinn.ApiClients.Maskinporten.Extensions;
 using Altinn.ApiClients.Maskinporten.Services;
 using Altinn.DialogportenAdapter.Contracts;
+using Altinn.DialogportenAdapter.WebApi.Common.Exceptions;
 using Altinn.DialogportenAdapter.WebApi.Common.Health;
 using Altinn.DialogportenAdapter.WebApi.Features.Command.Delete;
 using Altinn.DialogportenAdapter.WebApi.Features.Command.Sync;
@@ -127,6 +128,15 @@ internal static class ServiceCollectionExtensions
                     .OrAnyInner<PartyNotFoundException>()
                     .RetryWithJitteredCooldown(clock.Seconds(1), clock.Seconds(5), clock.Seconds(20))
                     .Then.ScheduleRetry(clock.Minutes(1), clock.Minutes(10), clock.Minutes(30))
+                    .Then.MoveToErrorQueue();
+
+                // DialogNotFoundForPurgeException may happen if the dialog is created and purged almost immediately
+                // Since we have no ordering of events, the purge event can come first. Reschedule for later.
+
+                opts.Policies
+                    .OnException<DialogNotFoundForPurgeException>()
+                    .OrAnyInner<DialogNotFoundForPurgeException>()
+                    .ScheduleRetry(clock.Minutes(1), clock.Minutes(10), clock.Minutes(30))
                     .Then.MoveToErrorQueue();
 
                 // Attempt to handle errors most likely caused by expired/invalid tokens. If retries don't help, move to error queue for manual inspection.

--- a/src/Altinn.DialogportenAdapter.WebApi/Common/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/Extensions/ServiceCollectionExtensions.cs
@@ -3,7 +3,6 @@ using Altinn.ApiClients.Dialogporten;
 using Altinn.ApiClients.Maskinporten.Extensions;
 using Altinn.ApiClients.Maskinporten.Services;
 using Altinn.DialogportenAdapter.Contracts;
-using Altinn.DialogportenAdapter.WebApi.Common.Exceptions;
 using Altinn.DialogportenAdapter.WebApi.Common.Health;
 using Altinn.DialogportenAdapter.WebApi.Features.Command.Delete;
 using Altinn.DialogportenAdapter.WebApi.Features.Command.Sync;
@@ -128,15 +127,6 @@ internal static class ServiceCollectionExtensions
                     .OrAnyInner<PartyNotFoundException>()
                     .RetryWithJitteredCooldown(clock.Seconds(1), clock.Seconds(5), clock.Seconds(20))
                     .Then.ScheduleRetry(clock.Minutes(1), clock.Minutes(10), clock.Minutes(30))
-                    .Then.MoveToErrorQueue();
-
-                // DialogNotFoundForPurgeException may happen if the dialog is created and purged almost immediately
-                // Since we have no ordering of events, the purge event can come first. Reschedule for later.
-
-                opts.Policies
-                    .OnException<DialogNotFoundForPurgeException>()
-                    .OrAnyInner<DialogNotFoundForPurgeException>()
-                    .ScheduleRetry(clock.Minutes(1), clock.Minutes(10), clock.Minutes(30))
                     .Then.MoveToErrorQueue();
 
                 // Attempt to handle errors most likely caused by expired/invalid tokens. If retries don't help, move to error queue for manual inspection.

--- a/src/Altinn.DialogportenAdapter.WebApi/Common/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/Extensions/ServiceCollectionExtensions.cs
@@ -130,9 +130,9 @@ internal static class ServiceCollectionExtensions
                     .Then.ScheduleRetry(clock.Minutes(1), clock.Minutes(10), clock.Minutes(30))
                     .Then.MoveToErrorQueue();
 
-                // DialogNotFoundForPurgeException may happen if the dialog is created and purged almost immediately
-                // Since we have no ordering of events, the purge event can come first. Reschedule for later.
-
+                // We sometimes see Purge returning 404, indicating the dialog has already been purged.
+                // This is probably due to a race where two events in quick succession decide to purge the dialog.
+                // A retry will make the adapter discard the event next run bt the intended way.
                 opts.Policies
                     .OnException<DialogNotFoundForPurgeException>()
                     .OrAnyInner<DialogNotFoundForPurgeException>()

--- a/src/Altinn.DialogportenAdapter.WebApi/Common/PartyNotFoundException.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/PartyNotFoundException.cs
@@ -1,3 +1,0 @@
-namespace Altinn.DialogportenAdapter.WebApi.Common;
-
-public class PartyNotFoundException(string? partyId) : InvalidOperationException($"Party with id {partyId} not found");

--- a/src/Altinn.DialogportenAdapter.WebApi/Common/PartyNotFoundException.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/PartyNotFoundException.cs
@@ -1,3 +1,3 @@
-namespace Altinn.DialogportenAdapter.WebApi.Common.Exceptions;
+namespace Altinn.DialogportenAdapter.WebApi.Common;
 
 public class PartyNotFoundException(string? partyId) : InvalidOperationException($"Party with id {partyId} not found");

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ISyncInstanceToDialogService.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ISyncInstanceToDialogService.cs
@@ -102,16 +102,16 @@ internal sealed partial class SyncInstanceToDialogService : ISyncInstanceToDialo
                 dialogId,
                 existingDialog.Revision!.Value,
                 isSilentUpdate: dto.IsMigration,
-                cancellationToken: cancellationToken);
+                cancellationToken: cancellationToken
+            );
 
-            if (response.IsSuccessful) return;
+            var problem = DpSimpleProblemDetails.FromFailedApiResponseIf(
+                response,
+                x => x.StatusCode == HttpStatusCode.NotFound
+            );
+            if (problem == null) return;
 
-            if (response.StatusCode == HttpStatusCode.NotFound)
-            {
-                throw new DialogNotFoundForPurgeException(dialogId, existingDialog.Revision.Value);
-            }
-
-            throw response.Error;
+            throw new DialogNotFoundForPurgeException(dialogId, existingDialog.Revision.Value, problem.TraceId);
         }
 
         if (ShouldSoftDeleteDialog(instance, existingDialog))

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ISyncInstanceToDialogService.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ISyncInstanceToDialogService.cs
@@ -1,8 +1,8 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
-using System.Text.Json;
 using Altinn.DialogportenAdapter.Contracts;
+using Altinn.DialogportenAdapter.WebApi.Common.Exceptions;
 using Altinn.DialogportenAdapter.WebApi.Common.Extensions;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Storage;
@@ -106,20 +106,9 @@ internal sealed partial class SyncInstanceToDialogService : ISyncInstanceToDialo
 
             if (response.IsSuccessful) return;
 
-            if (response.StatusCode == HttpStatusCode.NotFound && response.Error.HasContent)
+            if (response.StatusCode == HttpStatusCode.NotFound)
             {
-                var content = JsonSerializer.Deserialize<DialogportenSimpleProblemDetails>(response.Error.Content);
-                if (content is not null && content.Status == 404)
-                {
-                    LogPurgeWarning(
-                        dto.PartyId,
-                        dto.InstanceId,
-                        dialogId,
-                        existingDialog.Revision.Value,
-                        content.TraceId
-                    );
-                    return;
-                }
+                throw new DialogNotFoundForPurgeException(dialogId, existingDialog.Revision.Value);
             }
 
             throw response.Error;
@@ -337,10 +326,6 @@ internal sealed partial class SyncInstanceToDialogService : ISyncInstanceToDialo
 
     [LoggerMessage(LogLevel.Warning, "No dialog or instance found for request. {PartyId},{InstanceId},{InstanceCreatedAt},{IsMigration}.")]
     partial void LogNoOpWarning(string partyId, Guid instanceId, DateTimeOffset instanceCreatedAt, bool isMigration);
-
-
-    [LoggerMessage(LogLevel.Warning, "Can't purge dialog. Endpoint returned 404. Assuming already purged. {PartyId},{InstanceId},{dialogId}{revision},{traceId}.")]
-    partial void LogPurgeWarning(string partyId, Guid instanceId, Guid dialogId, Guid revision, string traceId);
 
     [LoggerMessage(LogLevel.Information, "Instance id={Id} is soft-deleted in storage and does not exist in Dialogporten. Creating and deleting immediately afterwards.")]
     partial void LogCreateDialogInSoftDeleteState(string id);

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ISyncInstanceToDialogService.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ISyncInstanceToDialogService.cs
@@ -1,8 +1,8 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
+using System.Text.Json;
 using Altinn.DialogportenAdapter.Contracts;
-using Altinn.DialogportenAdapter.WebApi.Common.Exceptions;
 using Altinn.DialogportenAdapter.WebApi.Common.Extensions;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Storage;
@@ -106,9 +106,20 @@ internal sealed partial class SyncInstanceToDialogService : ISyncInstanceToDialo
 
             if (response.IsSuccessful) return;
 
-            if (response.StatusCode == HttpStatusCode.NotFound)
+            if (response.StatusCode == HttpStatusCode.NotFound && response.Error.HasContent)
             {
-                throw new DialogNotFoundForPurgeException(dialogId, existingDialog.Revision.Value);
+                var content = JsonSerializer.Deserialize<DialogportenSimpleProblemDetails>(response.Error.Content);
+                if (content is not null && content.Status == 404)
+                {
+                    LogPurgeWarning(
+                        dto.PartyId,
+                        dto.InstanceId,
+                        dialogId,
+                        existingDialog.Revision.Value,
+                        content.TraceId
+                    );
+                    return;
+                }
             }
 
             throw response.Error;
@@ -326,6 +337,10 @@ internal sealed partial class SyncInstanceToDialogService : ISyncInstanceToDialo
 
     [LoggerMessage(LogLevel.Warning, "No dialog or instance found for request. {PartyId},{InstanceId},{InstanceCreatedAt},{IsMigration}.")]
     partial void LogNoOpWarning(string partyId, Guid instanceId, DateTimeOffset instanceCreatedAt, bool isMigration);
+
+
+    [LoggerMessage(LogLevel.Warning, "Can't purge dialog. Endpoint returned 404. Assuming already purged. {PartyId},{InstanceId},{dialogId}{revision},{traceId}.")]
+    partial void LogPurgeWarning(string partyId, Guid instanceId, Guid dialogId, Guid revision, string traceId);
 
     [LoggerMessage(LogLevel.Information, "Instance id={Id} is soft-deleted in storage and does not exist in Dialogporten. Creating and deleting immediately afterwards.")]
     partial void LogCreateDialogInSoftDeleteState(string id);

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ISyncInstanceToDialogService.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/ISyncInstanceToDialogService.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Net;
 using Altinn.DialogportenAdapter.Contracts;
+using Altinn.DialogportenAdapter.WebApi.Common.Exceptions;
 using Altinn.DialogportenAdapter.WebApi.Common.Extensions;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Storage;
@@ -96,23 +98,33 @@ internal sealed partial class SyncInstanceToDialogService : ISyncInstanceToDialo
         if (ShouldPurgeDialog(instance, existingDialog))
         {
             if (syncAdapterSettings.DisableDelete) return;
-            await _dialogportenApi.Purge(
+            var response = await _dialogportenApi.Purge(
                 dialogId,
                 existingDialog.Revision!.Value,
                 isSilentUpdate: dto.IsMigration,
                 cancellationToken: cancellationToken);
-            return;
+
+            if (response.IsSuccessful) return;
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                throw new DialogNotFoundForPurgeException(dialogId, existingDialog.Revision.Value);
+            }
+
+            throw response.Error;
         }
 
         if (ShouldSoftDeleteDialog(instance, existingDialog))
         {
             if (syncAdapterSettings.DisableDelete) return;
-            await _dialogportenApi.Delete(
+            var response = await _dialogportenApi.Delete(
                 dialogId,
                 existingDialog.Revision!.Value,
                 isSilentUpdate: dto.IsMigration,
                 cancellationToken: cancellationToken);
-            return;
+
+            if (response.IsSuccessful) return;
+            throw response.Error;
         }
 
         if (ShouldRestoreDialog(instance, existingDialog))
@@ -135,11 +147,14 @@ internal sealed partial class SyncInstanceToDialogService : ISyncInstanceToDialo
 
         if (!syncAdapterSettings.DisableDelete && shouldDeleteAfterCreate && revision.HasValue)
         {
-            await _dialogportenApi.Delete(
+            var response = await _dialogportenApi.Delete(
                 dialogId,
                 revision.Value,
                 isSilentUpdate: true,
                 cancellationToken: cancellationToken);
+
+            if (response.IsSuccessful) return;
+            throw response.Error;
         }
     }
 

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
@@ -1,4 +1,5 @@
 using Altinn.DialogportenAdapter.WebApi.Common;
+using Altinn.DialogportenAdapter.WebApi.Common.Exceptions;
 using Altinn.DialogportenAdapter.WebApi.Common.Extensions;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Register;

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
@@ -1,5 +1,4 @@
 using Altinn.DialogportenAdapter.WebApi.Common;
-using Altinn.DialogportenAdapter.WebApi.Common.Exceptions;
 using Altinn.DialogportenAdapter.WebApi.Common.Extensions;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Register;

--- a/src/Altinn.DialogportenAdapter.WebApi/Infrastructure/Dialogporten/DialogportenSimpleProblemDetails.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Infrastructure/Dialogporten/DialogportenSimpleProblemDetails.cs
@@ -1,9 +1,0 @@
-using System.Text.Json.Serialization;
-
-namespace Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
-
-public class DialogportenSimpleProblemDetails
-{
-    [JsonPropertyName("status")] public required int Status { get; set; }
-    [JsonPropertyName("traceId")] public required string TraceId { get; set; }
-}

--- a/src/Altinn.DialogportenAdapter.WebApi/Infrastructure/Dialogporten/DialogportenSimpleProblemDetails.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Infrastructure/Dialogporten/DialogportenSimpleProblemDetails.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
+
+public class DialogportenSimpleProblemDetails
+{
+    [JsonPropertyName("status")] public required int Status { get; set; }
+    [JsonPropertyName("traceId")] public required string TraceId { get; set; }
+}

--- a/src/Altinn.DialogportenAdapter.WebApi/Infrastructure/Dialogporten/DpSimpleProblemDetails.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Infrastructure/Dialogporten/DpSimpleProblemDetails.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Refit;
+
+namespace Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
+
+public class DpSimpleProblemDetails
+{
+    [JsonPropertyName("status")] public required int Status { get; set; }
+    [JsonPropertyName("traceId")] public required string TraceId { get; set; }
+
+    public static DpSimpleProblemDetails? FromFailedApiResponseIf(
+        IApiResponse response,
+        Predicate<IApiResponse> condition
+    )
+    {
+        if (response.IsSuccessful) return null;
+        if (response.Error == null)
+        {
+            var method = response.RequestMessage?.Method;
+            var uri = response.RequestMessage?.RequestUri;
+            throw new InvalidOperationException($"Request failed and error is null: {method} {uri}");
+        };
+
+        if (condition.Invoke(response) && response.Error.HasContent)
+        {
+            var problem = JsonSerializer.Deserialize<DpSimpleProblemDetails>(response.Error.Content!);
+            if (problem == null)
+            {
+                var method = response.RequestMessage?.Method;
+                var uri = response.RequestMessage?.RequestUri;
+                throw new InvalidOperationException($"Request failed and error deserialized to null: {method} {uri}");
+            }
+
+            return problem;
+        }
+
+        throw response.Error;
+    }
+}

--- a/src/Altinn.DialogportenAdapter.WebApi/Infrastructure/Dialogporten/DpSimpleProblemDetails.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Infrastructure/Dialogporten/DpSimpleProblemDetails.cs
@@ -20,7 +20,7 @@ public class DpSimpleProblemDetails
             var method = response.RequestMessage?.Method;
             var uri = response.RequestMessage?.RequestUri;
             throw new InvalidOperationException($"Request failed and error is null: {method} {uri}");
-        };
+        }
 
         if (condition.Invoke(response) && response.Error.HasContent)
         {

--- a/src/Altinn.DialogportenAdapter.WebApi/Infrastructure/Dialogporten/IDialogportenApi.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Infrastructure/Dialogporten/IDialogportenApi.cs
@@ -18,10 +18,10 @@ internal interface IDialogportenApi
     Task<IApiResponse> Update([Body] DialogDto dto, [Header(IfMatchHeader)] Guid revision, [Query] bool isSilentUpdate = false, CancellationToken cancellationToken = default);
 
     [Delete("/api/v1/serviceowner/dialogs/{dialogId}")]
-    Task Delete(Guid dialogId, [Header(IfMatchHeader)] Guid revision, [Query] bool isSilentUpdate = false, CancellationToken cancellationToken = default);
+    Task<IApiResponse> Delete(Guid dialogId, [Header(IfMatchHeader)] Guid revision, [Query] bool isSilentUpdate = false, CancellationToken cancellationToken = default);
 
     [Post("/api/v1/serviceowner/dialogs/{dialogId}/actions/purge")]
-    Task Purge(Guid dialogId, [Header(IfMatchHeader)] Guid revision, [Query] bool isSilentUpdate = false, CancellationToken cancellationToken = default);
+    Task<IApiResponse> Purge(Guid dialogId, [Header(IfMatchHeader)] Guid revision, [Query] bool isSilentUpdate = false, CancellationToken cancellationToken = default);
 
     [Post("/api/v1/serviceowner/dialogs/{dialogId}/actions/restore")]
     Task<IApiResponse> Restore(Guid dialogId, [Header(IfMatchHeader)] Guid revision, [Query] bool isSilentUpdate = false, CancellationToken cancellationToken = default);

--- a/src/Altinn.DialogportenAdapter.WebApi/Infrastructure/Dialogporten/MockDialogportenApi.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Infrastructure/Dialogporten/MockDialogportenApi.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using System.Net.Http.Headers;
 using Refit;
 
 namespace Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
@@ -52,18 +51,28 @@ internal sealed partial class MockDialogportenApi : IDialogportenApi
         return Task.FromResult<IApiResponse>(apiResponse);
     }
 
-    public Task Delete(Guid dialogId, Guid revision, bool isSilentUpdate = false,
+    public Task<IApiResponse> Delete(Guid dialogId, Guid revision, bool isSilentUpdate = false,
         CancellationToken cancellationToken = default)
     {
         Log.LogDeleteCalled(_logger, dialogId, revision);
-        return Task.CompletedTask;
+        var apiResponse = new ApiResponse<object>(
+            settings: _refitSettings,
+            response: new HttpResponseMessage(HttpStatusCode.OK),
+            content: null,
+            error: null);
+        return Task.FromResult<IApiResponse>(apiResponse);
     }
 
-    public Task Purge(Guid dialogId, Guid revision, bool isSilentUpdate = false,
+    public Task<IApiResponse> Purge(Guid dialogId, Guid revision, bool isSilentUpdate = false,
         CancellationToken cancellationToken = default)
     {
         Log.LogPurgeCalled(_logger, dialogId, revision);
-        return Task.CompletedTask;
+        var apiResponse = new ApiResponse<object>(
+            settings: _refitSettings,
+            response: new HttpResponseMessage(HttpStatusCode.OK),
+            content: null,
+            error: null);
+        return Task.FromResult<IApiResponse>(apiResponse);
     }
 
     public Task<IApiResponse> Restore(Guid dialogId, Guid revision, bool isSilentUpdate = false,

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Altinn.DialogportenAdapter.Integration.Tests.csproj
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Altinn.DialogportenAdapter.Integration.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Altinn.ApiClients.Dialogporten" Version="1.114.8" />
+    <PackageReference Include="Altinn.ApiClients.Dialogporten" Version="1.116.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
@@ -48,6 +48,8 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
         await DrainLeftoverMessages();
         await AdapterQueueDlqReceiver.DisposeAsync();
 
+        GetSyncJobCompleteSignal().Reset();
+
         GC.SuppressFinalize(this);
     }
 
@@ -94,27 +96,37 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
     {
         var maxWait = timeout ?? TimeSpan.FromSeconds(10);
         var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
-        var syncJobCompleteSignal = app.AppScope.ServiceProvider.GetRequiredService<SyncCompletionSignal>();
-        var syncJob = syncJobCompleteSignal.Completed.Task.WaitAsync(maxWait, cts.Token);
+        var syncJob = GetSyncJobCompleteSignal().Completed.Task.WaitAsync(maxWait, cts.Token);
         var getDlqMessage = WaitForDlqMessage(maxWait, cts.Token);
 
         await Task.WhenAny(syncJob, getDlqMessage);
-        await cts.CancelAsync();
-        syncJobCompleteSignal.Reset();
 
-        if (getDlqMessage.IsCompleted && !getDlqMessage.IsCanceled && getDlqMessage.Result != null)
+        if (getDlqMessage.IsFaulted)
         {
-            _unhandledEvents.TryDequeue(out _);
+            await cts.CancelAsync();
+            Assert.Fail("Unexpected error: WaitForDlqMessage should not throw");
+        }
+
+        if (getDlqMessage.IsCompletedSuccessfully && getDlqMessage.Result != null)
+        {
+            await cts.CancelAsync();
             return new EventProcessingResult(false, getDlqMessage.Result);
         }
 
-        if (!syncJob.IsCompletedSuccessfully)
+        if (syncJob.IsCompletedSuccessfully)
         {
-            return new EventProcessingResult(false, null);
+            await cts.CancelAsync();
+            _unhandledEvents.TryDequeue(out _);
+            return new EventProcessingResult(true, null);
         }
+        await cts.CancelAsync();
 
-        _unhandledEvents.TryDequeue(out _);
-        return new EventProcessingResult(true, null);
+        return new EventProcessingResult(false, null);
+    }
+
+    private SyncCompletionSignal GetSyncJobCompleteSignal()
+    {
+        return app.AppScope.ServiceProvider.GetRequiredService<SyncCompletionSignal>();
     }
 
     protected sealed record Arrangement(
@@ -271,11 +283,11 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
             if (DateTimeOffset.UtcNow > timeoutAt)
             {
                 Assert.Fail(
-                    $"Unable to drain dql: Timeout after {timeoutSeconds} seconds. This invalidates the whole test suite. Look for the test that failed to drain!");
+                    $"Unable to drain dql: Timeout after {timeoutSeconds} seconds. This invalidates the whole test suite. Look for the test that failed to drain! {_unhandledEvents.Count} undrained messages");
             }
 
             var message = await AdapterQueueDlqReceiver.ReceiveMessageAsync(
-                TimeSpan.FromMilliseconds(50),
+                TimeSpan.FromMilliseconds(200),
                 TestContext.Current.CancellationToken
             );
 

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
@@ -111,7 +111,6 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
         if (!syncJob.IsCompletedSuccessfully)
         {
             return new EventProcessingResult(false, null);
-            //Assert.Fail("Expected job to complete or any dlq event. Did the sync job throw an exception?");
         }
 
         _unhandledEvents.TryDequeue(out _);

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/Extensions/WireMockRequestExtensions.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/Extensions/WireMockRequestExtensions.cs
@@ -17,6 +17,11 @@ public static class WireMockRequestExtensions
             return requestBuilder.UsingPost().WithPath($"/api/v1/serviceowner/dialogs/{dialogId}/actions/purge");
         }
 
+        public IRequestBuilder DpDeleteDialog(Guid dialogId)
+        {
+            return requestBuilder.UsingDelete().WithPath($"/api/v1/serviceowner/dialogs/{dialogId}");
+        }
+
         public IRequestBuilder DpGetDialog(Guid dialogId)
         {
             return requestBuilder.UsingGet().WithPath($"/api/v1/serviceowner/dialogs/{dialogId}");

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/SyncDialogOnInstanceUpdatedHandlerDlqTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/SyncDialogOnInstanceUpdatedHandlerDlqTest.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Altinn.DialogportenAdapter.Contracts;
 using Altinn.DialogportenAdapter.Integration.Tests.Common;
 using Altinn.DialogportenAdapter.Integration.Tests.Common.Extensions;
+using Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Register;
 using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -205,5 +206,51 @@ public class SyncDialogOnInstanceUpdatedHandlerDlqTest(DialogportenAdapterApplic
 
         getDialogRequests.Should().BeGreaterThan(5);
         postDialogLogsRequests.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GivenPurgeDialogReturnsNotFoundThenDlqAfter3Retries()
+    {
+        // Arrange
+        var arrangement = ArrangeDefaults();
+        var dialogId = arrangement.DialogId;
+
+        _app.DialogportenApi
+            .Given(Request.Create().DpGetDialog(dialogId))
+            .RespondWith(Response.Create()
+                .WithStatusCode(HttpStatusCode.OK)
+                .WithBody(JsonSerializer.Serialize(new DialogDto
+                {
+                    Revision = Guid.NewGuid()
+                })));
+
+        _app.StorageApi
+            .Given(Request.Create().StorageGetInstance(arrangement.PartyId, arrangement.InstanceId))
+            .RespondWith(Response.Create()
+                .WithStatusCode(HttpStatusCode.NotFound));
+
+        _app.DialogportenApi
+            .Given(Request.Create().DpPurgeDialog(dialogId))
+            .RespondWith(Response.Create()
+                .WithStatusCode(HttpStatusCode.NotFound));
+
+        // Act
+        var result = await SendAndWait(new SyncInstanceCommand(
+            AppId: arrangement.AppId,
+            PartyId: $"{arrangement.PartyId}",
+            InstanceId: arrangement.InstanceId,
+            InstanceCreatedAt: arrangement.InstanceCreatedAt,
+            IsMigration: false
+        ));
+
+        // Assert
+        var purgeRequests = _app.DialogportenApi.FindLogEntries(Request.Create().DpPurgeDialog(dialogId)).Count;
+        var postRequests = _app.DialogportenApi.FindLogEntries(Request.Create().DpPostDialog()).Count;
+
+        result.IsSuccess.Should().BeFalse();
+        result.DlqMessage.Should().NotBeNull();
+        result.DlqMessage.DeadLetterErrorDescription.Should().Contain("Can't purge");
+        purgeRequests.Should().Be(4); // 3 retries + 1 requests
+        postRequests.Should().Be(0);
     }
 }

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/SyncDialogOnInstanceUpdatedHandlerDlqTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/SyncDialogOnInstanceUpdatedHandlerDlqTest.cs
@@ -214,6 +214,7 @@ public class SyncDialogOnInstanceUpdatedHandlerDlqTest(DialogportenAdapterApplic
         // Arrange
         var arrangement = ArrangeDefaults();
         var dialogId = arrangement.DialogId;
+        var traceId = "00-edeb32504e8b90d0ed578c6647316daf-2e15b2a2598daa08-00";
 
         _app.DialogportenApi
             .Given(Request.Create().DpGetDialog(dialogId))
@@ -232,7 +233,23 @@ public class SyncDialogOnInstanceUpdatedHandlerDlqTest(DialogportenAdapterApplic
         _app.DialogportenApi
             .Given(Request.Create().DpPurgeDialog(dialogId))
             .RespondWith(Response.Create()
-                .WithStatusCode(HttpStatusCode.NotFound));
+                .WithStatusCode(HttpStatusCode.NotFound)
+                .WithBody(
+                    $$"""
+                              {
+                                "type": "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.4",
+                                "title": "Resource not found.",
+                                "status": 404,
+                                "instance": "/api/v1/serviceowner/dialogs/{{dialogId}}/actions/purge",
+                                "errors": {
+                                  "DialogEntity": [
+                                    "Entity 'DialogEntity' with the following key(s) was not found: ({{dialogId}})."
+                                  ]
+                                },
+                                "traceId": "{{traceId}}"
+                              }
+                      """)
+            );
 
         // Act
         var result = await SendAndWait(new SyncInstanceCommand(
@@ -250,6 +267,7 @@ public class SyncDialogOnInstanceUpdatedHandlerDlqTest(DialogportenAdapterApplic
         result.IsSuccess.Should().BeFalse();
         result.DlqMessage.Should().NotBeNull();
         result.DlqMessage.DeadLetterErrorDescription.Should().Contain("Can't purge");
+        result.DlqMessage.DeadLetterErrorDescription.Should().Contain(traceId);
         purgeRequests.Should().Be(4); // 3 retries + 1 requests
         postRequests.Should().Be(0);
     }

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/SyncDialogOnInstanceUpdatedHandlerDlqTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/SyncDialogOnInstanceUpdatedHandlerDlqTest.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using Altinn.DialogportenAdapter.Contracts;
 using Altinn.DialogportenAdapter.Integration.Tests.Common;
 using Altinn.DialogportenAdapter.Integration.Tests.Common.Extensions;
-using Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Register;
 using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -206,51 +205,5 @@ public class SyncDialogOnInstanceUpdatedHandlerDlqTest(DialogportenAdapterApplic
 
         getDialogRequests.Should().BeGreaterThan(5);
         postDialogLogsRequests.Should().Be(0);
-    }
-
-    [Fact]
-    public async Task GivenPurgeDialogReturnsNotFoundThenDlqAfter3Retries()
-    {
-        // Arrange
-        var arrangement = ArrangeDefaults();
-        var dialogId = arrangement.DialogId;
-
-        _app.DialogportenApi
-            .Given(Request.Create().DpGetDialog(dialogId))
-            .RespondWith(Response.Create()
-                .WithStatusCode(HttpStatusCode.OK)
-                .WithBody(JsonSerializer.Serialize(new DialogDto
-                {
-                    Revision = Guid.NewGuid()
-                })));
-
-        _app.StorageApi
-            .Given(Request.Create().StorageGetInstance(arrangement.PartyId, arrangement.InstanceId))
-            .RespondWith(Response.Create()
-                .WithStatusCode(HttpStatusCode.NotFound));
-
-        _app.DialogportenApi
-            .Given(Request.Create().DpPurgeDialog(dialogId))
-            .RespondWith(Response.Create()
-                .WithStatusCode(HttpStatusCode.NotFound));
-
-        // Act
-        var result = await SendAndWait(new SyncInstanceCommand(
-            AppId: arrangement.AppId,
-            PartyId: $"{arrangement.PartyId}",
-            InstanceId: arrangement.InstanceId,
-            InstanceCreatedAt: arrangement.InstanceCreatedAt,
-            IsMigration: false
-        ));
-
-        // Assert
-        var purgeRequests = _app.DialogportenApi.FindLogEntries(Request.Create().DpPurgeDialog(dialogId)).Count;
-        var postRequests = _app.DialogportenApi.FindLogEntries(Request.Create().DpPostDialog()).Count;
-
-        result.IsSuccess.Should().BeFalse();
-        result.DlqMessage.Should().NotBeNull();
-        result.DlqMessage.DeadLetterErrorDescription.Should().Contain("Can't purge");
-        purgeRequests.Should().Be(4); // 3 retries + 1 requests
-        postRequests.Should().Be(0);
     }
 }

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/SyncDialogOnInstanceUpdatedHandlerTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/SyncDialogOnInstanceUpdatedHandlerTest.cs
@@ -43,14 +43,13 @@ public class SyncDialogOnInstanceUpdatedHandlerTest(DialogportenAdapterApplicati
     }
 
     [Fact]
-    public async Task GivenGetInstanceReturnsNotFoundAndExistingDialogThenDialogIsPurged()
+    public async Task GivenGetInstanceReturnsNotFoundThenDialogIsPurged()
     {
         // Arrange
         var arrangement = ArrangeDefaults();
-        var dialogId = arrangement.DialogId;
 
         _app.DialogportenApi
-            .Given(Request.Create().DpGetDialog(dialogId))
+            .Given(Request.Create().DpGetDialog(arrangement.DialogId))
             .RespondWith(Response.Create()
                 .WithStatusCode(HttpStatusCode.OK)
                 .WithBody(JsonSerializer.Serialize(new DialogDto
@@ -64,7 +63,7 @@ public class SyncDialogOnInstanceUpdatedHandlerTest(DialogportenAdapterApplicati
                 .WithStatusCode(HttpStatusCode.NotFound));
 
         _app.DialogportenApi
-            .Given(Request.Create().DpPurgeDialog(dialogId))
+            .Given(Request.Create().DpPurgeDialog(arrangement.DialogId))
             .RespondWith(Response.Create()
                 .WithStatusCode(HttpStatusCode.OK));
 
@@ -79,66 +78,7 @@ public class SyncDialogOnInstanceUpdatedHandlerTest(DialogportenAdapterApplicati
 
         // Assert
         result.ShouldBeSuccessful();
-        var purgeReqs = _app.DialogportenApi.FindLogEntries(Request.Create().DpPurgeDialog(dialogId)).Count;
-        var postReqs = _app.DialogportenApi.FindLogEntries(Request.Create().DpPostDialog()).Count;
-        purgeReqs.Should().Be(1);
-        postReqs.Should().Be(0);
-    }
-
-    [Fact]
-    public async Task GivenPurgeDialogReturnsNotFoundThenAssumeAlreadyPurged()
-    {
-        // Arrange
-        var arrangement = ArrangeDefaults();
-        var dialogId = arrangement.DialogId;
-
-        _app.DialogportenApi
-            .Given(Request.Create().DpGetDialog(dialogId))
-            .RespondWith(Response.Create()
-                .WithStatusCode(HttpStatusCode.OK)
-                .WithBody(JsonSerializer.Serialize(new DialogDto
-                {
-                    Revision = Guid.NewGuid()
-                })));
-
-        _app.StorageApi
-            .Given(Request.Create().StorageGetInstance(arrangement.PartyId, arrangement.InstanceId))
-            .RespondWith(Response.Create()
-                .WithStatusCode(HttpStatusCode.NotFound));
-
-        _app.DialogportenApi
-            .Given(Request.Create().DpPurgeDialog(dialogId))
-            .RespondWith(Response.Create()
-                .WithStatusCode(HttpStatusCode.NotFound)
-                .WithBody(
-                    $$"""
-                              {
-                                "type": "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.4",
-                                "title": "Resource not found.",
-                                "status": 404,
-                                "instance": "/api/v1/serviceowner/dialogs/{{dialogId}}/actions/purge",
-                                "errors": {
-                                  "DialogEntity": [
-                                    "Entity 'DialogEntity' with the following key(s) was not found: ({{dialogId}})."
-                                  ]
-                                },
-                                "traceId": "00-edeb32504e8b90d0ed578c6647316daf-2e15b2a2598daa08-00"
-                              }
-                      """)
-            );
-
-        // Act
-        var result = await SendAndWait(new SyncInstanceCommand(
-            AppId: arrangement.AppId,
-            PartyId: $"{arrangement.PartyId}",
-            InstanceId: arrangement.InstanceId,
-            InstanceCreatedAt: arrangement.InstanceCreatedAt,
-            IsMigration: false
-        ));
-
-        // Assert
-        result.ShouldBeSuccessful();
-        var purgeReqs = _app.DialogportenApi.FindLogEntries(Request.Create().DpPurgeDialog(dialogId)).Count;
+        var purgeReqs = _app.DialogportenApi.FindLogEntries(Request.Create().DpPurgeDialog(arrangement.DialogId)).Count;
         var postReqs = _app.DialogportenApi.FindLogEntries(Request.Create().DpPostDialog()).Count;
         purgeReqs.Should().Be(1);
         postReqs.Should().Be(0);

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/SyncDialogOnInstanceUpdatedHandlerTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/SyncDialogOnInstanceUpdatedHandlerTest.cs
@@ -43,13 +43,14 @@ public class SyncDialogOnInstanceUpdatedHandlerTest(DialogportenAdapterApplicati
     }
 
     [Fact]
-    public async Task GivenGetInstanceReturnsNotFoundThenDialogIsPurged()
+    public async Task GivenGetInstanceReturnsNotFoundAndExistingDialogThenDialogIsPurged()
     {
         // Arrange
         var arrangement = ArrangeDefaults();
+        var dialogId = arrangement.DialogId;
 
         _app.DialogportenApi
-            .Given(Request.Create().DpGetDialog(arrangement.DialogId))
+            .Given(Request.Create().DpGetDialog(dialogId))
             .RespondWith(Response.Create()
                 .WithStatusCode(HttpStatusCode.OK)
                 .WithBody(JsonSerializer.Serialize(new DialogDto
@@ -63,7 +64,7 @@ public class SyncDialogOnInstanceUpdatedHandlerTest(DialogportenAdapterApplicati
                 .WithStatusCode(HttpStatusCode.NotFound));
 
         _app.DialogportenApi
-            .Given(Request.Create().DpPurgeDialog(arrangement.DialogId))
+            .Given(Request.Create().DpPurgeDialog(dialogId))
             .RespondWith(Response.Create()
                 .WithStatusCode(HttpStatusCode.OK));
 
@@ -78,7 +79,66 @@ public class SyncDialogOnInstanceUpdatedHandlerTest(DialogportenAdapterApplicati
 
         // Assert
         result.ShouldBeSuccessful();
-        var purgeReqs = _app.DialogportenApi.FindLogEntries(Request.Create().DpPurgeDialog(arrangement.DialogId)).Count;
+        var purgeReqs = _app.DialogportenApi.FindLogEntries(Request.Create().DpPurgeDialog(dialogId)).Count;
+        var postReqs = _app.DialogportenApi.FindLogEntries(Request.Create().DpPostDialog()).Count;
+        purgeReqs.Should().Be(1);
+        postReqs.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GivenPurgeDialogReturnsNotFoundThenAssumeAlreadyPurged()
+    {
+        // Arrange
+        var arrangement = ArrangeDefaults();
+        var dialogId = arrangement.DialogId;
+
+        _app.DialogportenApi
+            .Given(Request.Create().DpGetDialog(dialogId))
+            .RespondWith(Response.Create()
+                .WithStatusCode(HttpStatusCode.OK)
+                .WithBody(JsonSerializer.Serialize(new DialogDto
+                {
+                    Revision = Guid.NewGuid()
+                })));
+
+        _app.StorageApi
+            .Given(Request.Create().StorageGetInstance(arrangement.PartyId, arrangement.InstanceId))
+            .RespondWith(Response.Create()
+                .WithStatusCode(HttpStatusCode.NotFound));
+
+        _app.DialogportenApi
+            .Given(Request.Create().DpPurgeDialog(dialogId))
+            .RespondWith(Response.Create()
+                .WithStatusCode(HttpStatusCode.NotFound)
+                .WithBody(
+                    $$"""
+                              {
+                                "type": "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.4",
+                                "title": "Resource not found.",
+                                "status": 404,
+                                "instance": "/api/v1/serviceowner/dialogs/{{dialogId}}/actions/purge",
+                                "errors": {
+                                  "DialogEntity": [
+                                    "Entity 'DialogEntity' with the following key(s) was not found: ({{dialogId}})."
+                                  ]
+                                },
+                                "traceId": "00-edeb32504e8b90d0ed578c6647316daf-2e15b2a2598daa08-00"
+                              }
+                      """)
+            );
+
+        // Act
+        var result = await SendAndWait(new SyncInstanceCommand(
+            AppId: arrangement.AppId,
+            PartyId: $"{arrangement.PartyId}",
+            InstanceId: arrangement.InstanceId,
+            InstanceCreatedAt: arrangement.InstanceCreatedAt,
+            IsMigration: false
+        ));
+
+        // Assert
+        result.ShouldBeSuccessful();
+        var purgeReqs = _app.DialogportenApi.FindLogEntries(Request.Create().DpPurgeDialog(dialogId)).Count;
         var postReqs = _app.DialogportenApi.FindLogEntries(Request.Create().DpPostDialog()).Count;
         purgeReqs.Should().Be(1);
         postReqs.Should().Be(0);

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/SyncDialogOnInstanceUpdatedHandlerTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/SyncDialogOnInstanceUpdatedHandlerTest.cs
@@ -1,9 +1,14 @@
-﻿using Altinn.DialogportenAdapter.Contracts;
+﻿using System.Net;
+using System.Text.Json;
+using Altinn.DialogportenAdapter.Contracts;
 using Altinn.DialogportenAdapter.Integration.Tests.Common;
 using Altinn.DialogportenAdapter.Integration.Tests.Common.Extensions;
+using Altinn.DialogportenAdapter.Test.Common.Builder;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
+using Altinn.Platform.Storage.Interface.Models;
 using AwesomeAssertions;
 using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
 using Xunit;
 
 namespace Altinn.DialogportenAdapter.Integration.Tests.WebApi;
@@ -35,5 +40,154 @@ public class SyncDialogOnInstanceUpdatedHandlerTest(DialogportenAdapterApplicati
 
         logEntries.Count.Should().Be(1);
         logEntries[0].RequestMessage!.Deserialize<DialogDto>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GivenGetInstanceReturnsNotFoundThenDialogIsPurged()
+    {
+        // Arrange
+        var arrangement = ArrangeDefaults();
+
+        _app.DialogportenApi
+            .Given(Request.Create().DpGetDialog(arrangement.DialogId))
+            .RespondWith(Response.Create()
+                .WithStatusCode(HttpStatusCode.OK)
+                .WithBody(JsonSerializer.Serialize(new DialogDto
+                {
+                    Revision = Guid.NewGuid()
+                })));
+
+        _app.StorageApi
+            .Given(Request.Create().StorageGetInstance(arrangement.PartyId, arrangement.InstanceId))
+            .RespondWith(Response.Create()
+                .WithStatusCode(HttpStatusCode.NotFound));
+
+        _app.DialogportenApi
+            .Given(Request.Create().DpPurgeDialog(arrangement.DialogId))
+            .RespondWith(Response.Create()
+                .WithStatusCode(HttpStatusCode.OK));
+
+        // Act
+        var result = await SendAndWait(new SyncInstanceCommand(
+            AppId: arrangement.AppId,
+            PartyId: $"{arrangement.PartyId}",
+            InstanceId: arrangement.InstanceId,
+            InstanceCreatedAt: arrangement.InstanceCreatedAt,
+            IsMigration: false
+        ));
+
+        // Assert
+        result.ShouldBeSuccessful();
+        var purgeReqs = _app.DialogportenApi.FindLogEntries(Request.Create().DpPurgeDialog(arrangement.DialogId)).Count;
+        var postReqs = _app.DialogportenApi.FindLogEntries(Request.Create().DpPostDialog()).Count;
+        purgeReqs.Should().Be(1);
+        postReqs.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GivenSoftDeletedInstanceAndExistingDialogThenDialogIsDeletedAndNotCreated()
+    {
+        // Arrange
+        var arrangement = ArrangeDefaults();
+
+        _app.DialogportenApi
+            .Given(Request.Create().DpGetDialog(arrangement.DialogId))
+            .RespondWith(Response.Create()
+                .WithStatusCode(HttpStatusCode.OK)
+                .WithBody(JsonSerializer.Serialize(new DialogDto
+                {
+                    Revision = Guid.NewGuid()
+                })));
+
+        _app.StorageApi
+            .Given(Request.Create().StorageGetInstance(arrangement.PartyId, arrangement.InstanceId))
+            .AtPriority(short.MaxValue - 1)
+            .RespondWith(Response.Create()
+                .WithStatusCode(HttpStatusCode.OK)
+                .WithBody(JsonSerializer.Serialize(AltinnInstanceBuilder
+                    .NewInProgressInstance()
+                    .WithCreatedBy(TestContext.Current.Test!.TestDisplayName)
+                    .WithInstanceOwner(new InstanceOwner
+                    {
+                        PartyId = $"{arrangement.PartyId}",
+                    })
+                    .WithStatus(new InstanceStatus
+                    {
+                        IsSoftDeleted = true,
+                    })
+                    .Build())));
+
+        _app.DialogportenApi
+            .Given(Request.Create().DpDeleteDialog(arrangement.DialogId))
+            .RespondWith(Response.Create()
+                .WithStatusCode(HttpStatusCode.OK));
+
+        // Act
+        var result = await SendAndWait(new SyncInstanceCommand(
+            AppId: arrangement.AppId,
+            PartyId: $"{arrangement.PartyId}",
+            InstanceId: arrangement.InstanceId,
+            InstanceCreatedAt: arrangement.InstanceCreatedAt,
+            IsMigration: false
+        ));
+
+        // Assert
+        result.ShouldBeSuccessful();
+        var deleteReqs = _app.DialogportenApi
+            .FindLogEntries(Request.Create().DpDeleteDialog(arrangement.DialogId))
+            .Count;
+        var postReq = _app.DialogportenApi.FindLogEntries(Request.Create().DpPostDialog()).Count;
+
+        deleteReqs.Should().Be(1);
+        postReq.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GivenSoftDeletedInstanceAndNoExistingDialogThenDialogIsCreatedAndDeleted()
+    {
+        // Arrange
+        var arrangement = ArrangeDefaults();
+
+        _app.StorageApi
+            .Given(Request.Create().StorageGetInstance(arrangement.PartyId, arrangement.InstanceId))
+            .AtPriority(short.MaxValue - 1)
+            .RespondWith(Response.Create()
+                .WithStatusCode(HttpStatusCode.OK)
+                .WithBody(JsonSerializer.Serialize(AltinnInstanceBuilder
+                    .NewInProgressInstance()
+                    .WithCreatedBy(TestContext.Current.Test!.TestDisplayName)
+                    .WithInstanceOwner(new InstanceOwner
+                    {
+                        PartyId = $"{arrangement.PartyId}",
+                    })
+                    .WithStatus(new InstanceStatus
+                    {
+                        IsSoftDeleted = true,
+                    })
+                    .Build())));
+
+        _app.DialogportenApi
+            .Given(Request.Create().DpDeleteDialog(arrangement.DialogId))
+            .RespondWith(Response.Create()
+                .WithStatusCode(HttpStatusCode.OK));
+
+        // Act
+        var result = await SendAndWait(new SyncInstanceCommand(
+            AppId: arrangement.AppId,
+            PartyId: $"{arrangement.PartyId}",
+            InstanceId: arrangement.InstanceId,
+            InstanceCreatedAt: arrangement.InstanceCreatedAt,
+            IsMigration: false
+        ));
+
+        // Assert
+        result.ShouldBeSuccessful();
+        var postReq = _app.DialogportenApi.FindLogEntries(Request.Create().DpPostDialog()).Count;
+        var deleteReqs = _app.DialogportenApi
+            .FindLogEntries(Request.Create().DpDeleteDialog(arrangement.DialogId))
+            .Count;
+
+        postReq.Should().Be(1);
+        deleteReqs.Should().Be(1);
     }
 }


### PR DESCRIPTION
- If the create and purge events come in quick succession, we need to re-schedule the purge event if it wins the race and fails the purge request

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- https://github.com/Altinn/altinn-dialogporten-adapter/issues/226

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delete/purge handling to inspect API responses, surface error details (including trace IDs), treat 404 purge as a purge-not-found failure, and trigger retries/DLQ where appropriate.
  * Restored a distinct "party not found" error for clearer missing-party reporting.

* **Tests**
  * Added integration tests covering purge/delete flows, soft-delete behavior, NotFound scenarios, retries, DLQ outcomes, and a WireMock DELETE helper.

* **Chores**
  * Added simple problem-details parsing, adjusted API response handling and mocks, updated retry policies and package versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->