### PR TITLE
Increase clientside HTTP timeout to handle very large instances

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Common/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/Extensions/ServiceCollectionExtensions.cs
@@ -245,7 +245,11 @@ internal static class ServiceCollectionExtensions
 
             services
                 .AddRefitClient<IDialogportenApi>()
-                .ConfigureHttpClient(x => x.BaseAddress = settings.DialogportenAdapter.Dialogporten.BaseUri)
+                .ConfigureHttpClient(x =>
+                {
+                    x.BaseAddress = settings.DialogportenAdapter.Dialogporten.BaseUri;
+                    x.Timeout = TimeSpan.FromMinutes(10);
+                })
                 .AddMaskinportenHttpMessageHandler<SettingsJwkClientDefinition>(clientKey)
                 .AddHttpMessageHandler<FourHundredLoggingDelegatingHandler>();
 


### PR DESCRIPTION
This increases the timeout on the Dialogporten HTTP client from the default 100 seconds, in order to handle very large instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured HTTP client with an explicit 10-minute request timeout to prevent requests from hanging indefinitely. This enhances system reliability and ensures consistent, predictable behavior for all API operations under various network conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-dialogporten-adapter/pull/238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->