### PR TITLE
fix: increase Wolverine message timeout

### DIFF
--- a/src/Altinn.DialogportenAdapter.Contracts/SyncInstanceCommand.cs
+++ b/src/Altinn.DialogportenAdapter.Contracts/SyncInstanceCommand.cs
@@ -4,7 +4,7 @@ namespace Altinn.DialogportenAdapter.Contracts;
 
 [MessageIdentity("Altinn.DialogportenAdapter.SyncInstanceCommand")]
 // This is intentionally more than the HTTP timeout set in ServiceCollectionExtensions,
-// where .AddRefitClient<IDialogportenApi>() sets the HTTP level timeout to 10 minutes,
+// where .AddRefitClient<IDialogportenApi>() sets the HTTP level timeout to 15 minutes,
 // making it the effective limit. Note that messages holding a lock for more than
 // 5 minutes will throw, as the max lock duration is 5 minutes in ASB. The message
 // will still be processed, but might require manual intervention to clear from the

--- a/src/Altinn.DialogportenAdapter.Contracts/SyncInstanceCommand.cs
+++ b/src/Altinn.DialogportenAdapter.Contracts/SyncInstanceCommand.cs
@@ -3,6 +3,13 @@
 namespace Altinn.DialogportenAdapter.Contracts;
 
 [MessageIdentity("Altinn.DialogportenAdapter.SyncInstanceCommand")]
+// This is intentionally more than the HTTP timeout set in ServiceCollectionExtensions,
+// where .AddRefitClient<IDialogportenApi>() sets the HTTP level timeout to 10 minutes,
+// making it the effective limit. Note that messages holding a lock for more than
+// 5 minutes will throw, as the max lock duration is 5 minutes in ASB. The message
+// will still be processed, but might require manual intervention to clear from the
+// queue to avoid needless retries.
+[MessageTimeout(30 * 60)]
 public record SyncInstanceCommand(
     string AppId,
     string PartyId,

--- a/src/Altinn.DialogportenAdapter.WebApi/Common/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/Extensions/ServiceCollectionExtensions.cs
@@ -248,7 +248,7 @@ internal static class ServiceCollectionExtensions
                 .ConfigureHttpClient(x =>
                 {
                     x.BaseAddress = settings.DialogportenAdapter.Dialogporten.BaseUri;
-                    x.Timeout = TimeSpan.FromMinutes(10);
+                    x.Timeout = TimeSpan.FromMinutes(15); // See also SyncInstanceCommand.cs
                 })
                 .AddMaskinportenHttpMessageHandler<SettingsJwkClientDefinition>(clientKey)
                 .AddHttpMessageHandler<FourHundredLoggingDelegatingHandler>();


### PR DESCRIPTION
The previous attempt to increase the limit was insufficient, as Wolverine by default cancels a sync message after 60 seconds. This increases the timeout substantially.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated timeout configurations for sync operations and API calls to improve handling of long-running requests. Message processing timeout set to 30 minutes; HTTP client timeout increased to 15 minutes for better stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-dialogporten-adapter/pull/239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->