### PR TITLE
fix: add workaround for missing task handling in dialogtokenvalidator

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Delete/InstanceService.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Delete/InstanceService.cs
@@ -43,7 +43,8 @@ internal sealed class InstanceService
         }
 
         var dialogId = request.InstanceGuid.ToVersion7(instance.Created!.Value);
-        if (!ValidateDialogToken(request.DialogToken, dialogId))
+
+        if (!ValidateDialogToken(request.DialogToken, dialogId, instance))
         {
             return new DeleteResponse.UnAuthorized();
         }
@@ -65,14 +66,32 @@ internal sealed class InstanceService
         return new DeleteResponse.Success();
     }
 
-    private bool ValidateDialogToken(ReadOnlySpan<char> token, Guid dialogId)
+    private bool ValidateDialogToken(ReadOnlySpan<char> token, Guid dialogId, Instance instance)
     {
         const string bearerPrefix = "Bearer ";
         token = token.StartsWith(bearerPrefix, StringComparison.OrdinalIgnoreCase)
             ? token[bearerPrefix.Length..]
             : token;
         var result = _dialogTokenValidator.Validate(token, dialogId, ["delete"]);
+
+        if (!result.IsValid)
+        {
+            // The dialog token might contain an action including the current task, ie "delete,urn:altinn:task:Task_1"
+            // We need to check that as well
+            var currentTaskId = GetCurrentProcessTask(instance);
+            if (currentTaskId != null)
+            {
+                result = _dialogTokenValidator.Validate(token, dialogId, [$"delete,{currentTaskId}"]);
+            }
+        }
         return result.IsValid;
+    }
+
+    private static string? GetCurrentProcessTask(Instance instance)
+    {
+        return !string.IsNullOrWhiteSpace(instance.Process?.CurrentTask?.ElementId)
+            ? "urn:altinn:task:" + instance.Process.CurrentTask.ElementId
+            : null;
     }
 
     private static bool IsDeletable(Instance instance, Application app)


### PR DESCRIPTION
## Description
https://github.com/Altinn/dialogporten/issues/3179 introduced authorizationAttributes to delete actions. The way the dialog token validator is set up, this caused delete requests to be denied

## Related Issue(s)
- https://github.com/Altinn/altinn-support-private/issues/5019

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced token validation logic for instance deletion operations to support more granular authorization scoping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->