### PR TITLE
Fix status/attachments for A1 form instances

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
@@ -264,7 +264,7 @@ internal sealed class StorageDialogportenDataMerger
         MergeDto dto,
         List<ActivityDto> activities)
     {
-        var data = dto.Instance.Data;
+        var data = dto.Instance.Data.Where(x => !ShouldSkipDataElement(x));
         var attachmentVisibility = ReceiptAttachmentVisibilityDecider.Create(dto.Application);
 
         if (TransmissionsDisabled())
@@ -301,6 +301,9 @@ internal sealed class StorageDialogportenDataMerger
 
         bool IsPerformedBySo(DataElement element) => element.LastChangedBy.Length == 9;
         bool IsNotPdfReceipt(DataElement element) => element.DataType != PdfType;
+
+        // We hide the A1 "Signatures.html" from DP/AF
+        bool ShouldSkipDataElement(DataElement element) => IsA1Instance(dto.Instance) && element.DataType == "signature-presentation";
 
         bool TransmissionsDisabled() => dto.Application.GetSyncAdapterSettings().DisableAddTransmissions ||
                                         !_settings.DialogportenAdapter.Adapter.FeatureFlag
@@ -577,7 +580,7 @@ internal sealed class StorageDialogportenDataMerger
 
     private static bool IsConsideredConfirmed(Instance instance)
     {
-        if (IsA2Instance(instance)) // Archived in Altinn 2, always considered confirmed
+        if (IsA2Instance(instance) || IsA1Instance(instance)) // Archived in Altinn 1/2, always considered confirmed
         {
             return true;
         }
@@ -588,6 +591,11 @@ internal sealed class StorageDialogportenDataMerger
     private static bool IsA2Instance(Instance instance)
     {
         return instance.DataValues is not null && instance.DataValues.ContainsKey("A2ArchRef");
+    }
+
+    private static bool IsA1Instance(Instance instance)
+    {
+        return instance.DataValues is not null && instance.DataValues.ContainsKey("A1ArchRef");
     }
 
     /// <summary>


### PR DESCRIPTION
## Description

This fixes A1 dialog creation:

- Sets status to "Completed"
- Hides the "Signatures.html" attachment

There are no real A1 instances in TT02, so this is hard to test.

## Related Issue(s)
- #243

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Excluded signature-presentation artifacts from outgoing transmission payloads to avoid unwanted attachments and improve message cleanliness.
  * Revised archived-instance confirmation rules so applicable archived instances are consistently treated as confirmed, improving status accuracy and summary displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->