### PR TITLE
Stabilize tests

### DIFF
--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/AzureServiceBusEmulator/Config.json
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/AzureServiceBusEmulator/Config.json
@@ -1,0 +1,43 @@
+{
+  "UserConfig": {
+    "Namespaces": [
+      {
+        "Name": "sbemulatorns",
+        "Queues": [
+          {
+            "Name": "altinn.dialogportenadapter.webapi",
+            "Properties": {
+              "DeadLetteringOnMessageExpiration": false,
+              "DefaultMessageTimeToLive": "PT1H",
+              "DuplicateDetectionHistoryTimeWindow": "PT20S",
+              //"ForwardDeadLetteredMessagesTo": "",
+              //"ForwardTo": "",
+              "LockDuration": "PT15S", // We reduce the lock duration to speed up tests
+              "MaxDeliveryCount": 10,
+              "RequiresDuplicateDetection": true,
+              "RequiresSession": false
+            }
+          },
+          {
+            "Name": "altinn.dialogportenadapter-history.webapi",
+            "Properties": {
+              "DeadLetteringOnMessageExpiration": false,
+              "DefaultMessageTimeToLive": "PT1H",
+              "DuplicateDetectionHistoryTimeWindow": "PT20S",
+              //"ForwardDeadLetteredMessagesTo": "",
+              //"ForwardTo": "",
+              "LockDuration": "PT15S", // We reduce the lock duration to speed up tests
+              "MaxDeliveryCount": 10,
+              "RequiresDuplicateDetection": true,
+              "RequiresSession": false
+            }
+          }
+        ],
+        "Topics": []
+      }
+    ],
+    "Logging": {
+      "Type": "File"
+    }
+  }
+}

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
@@ -69,7 +69,7 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
         cancellationToken.ThrowIfCancellationRequested();
         if (message != null)
         {
-            await AdapterQueueDlqReceiver.CompleteMessageAsync(message, cancellationToken);
+            await AdapterQueueDlqReceiver.CompleteMessageAsync(message, CancellationToken.None);
             _unhandledEvents.TryDequeue(out _);
         }
 

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
@@ -131,7 +131,7 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
         {
             await task;
         }
-        catch (TaskCanceledException)
+        catch (OperationCanceledException)
         {
             // Ignore
         }

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
@@ -120,6 +120,7 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
         }
 
         await cts.CancelAsync();
+        await IgnoreCancellation(getDlqMessage);
 
         return new EventProcessingResult(false, null);
     }

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.Net;
 using System.Text.Json;
 using Altinn.DialogportenAdapter.Contracts;
@@ -70,7 +71,8 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
         if (message != null)
         {
             await AdapterQueueDlqReceiver.CompleteMessageAsync(message, CancellationToken.None);
-            _unhandledEvents.TryDequeue(out _);
+            _unhandledEvents.TryDequeue(out var handledEvent);
+            Log($"Debug: Received event on DLQ {handledEvent}");
         }
 
         return message;
@@ -114,7 +116,8 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
         {
             await cts.CancelAsync();
             await IgnoreCancellation(getDlqMessage);
-            _unhandledEvents.TryDequeue(out _);
+            _unhandledEvents.TryDequeue(out var handledEvent);
+            Log($"Debug: An event was successfully handled {handledEvent}");
 
             return new EventProcessingResult(true, null);
         }
@@ -133,7 +136,7 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
         }
         catch (OperationCanceledException)
         {
-            // Ignore
+            Log($"Debug: Ignored a task that was cancelled");
         }
     }
 
@@ -293,6 +296,8 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
     private async Task DrainLeftoverMessages()
     {
         if (_unhandledEvents.IsEmpty) return;
+        Log("Warning: Found unhandled messages, draining leftover messages");
+
         var timeoutSeconds = 60;
         var start = DateTimeOffset.UtcNow;
         await using var dlqReceiver = CreateReceiver();
@@ -306,7 +311,7 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
             }
 
             var dlqMessage = await dlqReceiver.ReceiveMessageAsync(
-                TimeSpan.FromSeconds(timeoutSeconds),
+                TimeSpan.FromSeconds(timeoutSeconds / 3),
                 TestContext.Current.CancellationToken
             );
 
@@ -314,7 +319,7 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
             {
                 await dlqReceiver.CompleteMessageAsync(dlqMessage);
                 _unhandledEvents.TryDequeue(out var unhandledEvent);
-                TestContext.Current.TestOutputHelper!.WriteLine($"Warning: Drained event {unhandledEvent}");
+                Log($"Warning: Drained event {unhandledEvent}");
             }
         }
     }
@@ -329,5 +334,11 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
                 PrefetchCount = 0
             }
         );
+    }
+
+    private static void Log(string message)
+    {
+        var time = DateTime.UtcNow.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture);
+        TestContext.Current.TestOutputHelper!.WriteLine($"{time} ({Environment.CurrentManagedThreadId}): {message}");
     }
 }

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
@@ -298,7 +298,7 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
         if (_unhandledEvents.IsEmpty) return;
         Log("Warning: Found unhandled messages, draining leftover messages");
 
-        var timeoutSeconds = 120;
+        var timeoutSeconds = 65;
         var start = DateTimeOffset.UtcNow;
         while (!_unhandledEvents.IsEmpty)
         {

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
@@ -25,22 +25,32 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
 
     public ValueTask InitializeAsync()
     {
-        AdapterQueueDlqReceiver = CreateDlqReceiver();
+        AdapterQueueDlqReceiver = app.ServiceBusClient.CreateReceiver(
+            Constants.AdapterQueueName,
+            new ServiceBusReceiverOptions
+            {
+                SubQueue = SubQueue.DeadLetter,
+                PrefetchCount = 0
+            }
+        );
 
         return ValueTask.CompletedTask;
     }
 
     public async ValueTask DisposeAsync()
     {
+        // Dispose asap, so a test doesn't accidentally consume a fallback mapping
+        await AdapterQueueDlqReceiver.DisposeAsync();
+
         app.DialogportenApi.LogUnhandledRequests(app.App.Logger, "DialogportenApi").ResetAllExceptFallbackMapping();
         app.RegisterApi.LogUnhandledRequests(app.App.Logger, "RegisterApi").ResetAllExceptFallbackMapping();
         app.AltinnApi.LogUnhandledRequests(app.App.Logger, "AltinnApi").ResetAllExceptFallbackMapping();
         app.StorageApi.LogUnhandledRequests(app.App.Logger, "StorageApi").ResetAllExceptFallbackMapping();
-        await AdapterQueueDlqReceiver.DisposeAsync();
 
-        await app.App.Services.GetRequiredService<IFusionCache>().ClearAsync();
-        await DrainLeftoverMessages();
         GetSyncJobCompleteSignal().Reset();
+        var clearCache = app.App.Services.GetRequiredService<IFusionCache>().ClearAsync().AsTask();
+        var drainMessages = DrainLeftoverMessages();
+        await Task.WhenAll(clearCache, drainMessages);
 
         GC.SuppressFinalize(this);
     }
@@ -62,6 +72,7 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
         var maxWait = timeout ?? TimeSpan.FromSeconds(10);
         var message = await AdapterQueueDlqReceiver.ReceiveMessageAsync(maxWait, cancellationToken);
 
+        cancellationToken.ThrowIfCancellationRequested();
         if (message != null)
         {
             await AdapterQueueDlqReceiver.CompleteMessageAsync(message, cancellationToken);
@@ -274,18 +285,25 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
     {
         if (_unhandledEvents.IsEmpty) return;
         var timeoutSeconds = 60;
-        var timeoutAt = DateTimeOffset.UtcNow.AddSeconds(timeoutSeconds);
-        await using var dlqReceiver = CreateDlqReceiver();
+        var start = DateTimeOffset.UtcNow;
+        await using var dlqReceiver = app.ServiceBusClient.CreateReceiver(
+            Constants.AdapterQueueName,
+            new ServiceBusReceiverOptions
+            {
+                SubQueue = SubQueue.DeadLetter,
+            }
+        );
         while (!_unhandledEvents.IsEmpty)
         {
-            if (DateTimeOffset.UtcNow > timeoutAt)
+            var elapsed = DateTimeOffset.UtcNow - start;
+            if (elapsed.Seconds > timeoutSeconds)
             {
                 Assert.Fail(
-                    $"Unable to drain dql: Timeout after {timeoutSeconds} seconds. This invalidates the whole test suite. Look for the test that failed to drain! {_unhandledEvents.Count} undrained messages");
+                    $"Unable to drain dql: Timeout after {elapsed} seconds. This invalidates the whole test suite. Look for the test that failed to drain! {_unhandledEvents.Count} undrained messages");
             }
 
             var dlqMessage = await dlqReceiver.ReceiveMessageAsync(
-                TimeSpan.FromMilliseconds(200),
+                TimeSpan.FromSeconds(timeoutSeconds),
                 TestContext.Current.CancellationToken
             );
 
@@ -295,16 +313,5 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
                 _unhandledEvents.TryDequeue(out _);
             }
         }
-    }
-
-    private ServiceBusReceiver CreateDlqReceiver()
-    {
-        return app.ServiceBusClient.CreateReceiver(
-            Constants.AdapterQueueName,
-            new ServiceBusReceiverOptions
-            {
-                SubQueue = SubQueue.DeadLetter,
-            }
-        );
     }
 }

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
@@ -20,6 +20,7 @@ namespace Altinn.DialogportenAdapter.Integration.Tests.Common;
 
 public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication app) : IAsyncLifetime
 {
+    private const int DefaultWaitSeconds = 20;
     private ServiceBusReceiver AdapterQueueDlqReceiver { get; set; } = null!;
     private readonly ConcurrentQueue<object> _unhandledEvents = new();
 
@@ -69,7 +70,7 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
         CancellationToken cancellationToken = default
     )
     {
-        var maxWait = timeout ?? TimeSpan.FromSeconds(10);
+        var maxWait = timeout ?? TimeSpan.FromSeconds(DefaultWaitSeconds);
         var message = await AdapterQueueDlqReceiver.ReceiveMessageAsync(maxWait, cancellationToken);
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -97,7 +98,7 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
 
     private async Task<EventProcessingResult> GetEventProcessingResult(TimeSpan? timeout = null)
     {
-        var maxWait = timeout ?? TimeSpan.FromSeconds(10);
+        var maxWait = timeout ?? TimeSpan.FromSeconds(DefaultWaitSeconds);
         var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         var syncJob = GetSyncJobCompleteSignal().Completed.Task.WaitAsync(maxWait, cts.Token);
         var getDlqMessage = WaitForDlqMessage(maxWait, cts.Token);
@@ -310,7 +311,8 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
             if (dlqMessage != null)
             {
                 await dlqReceiver.CompleteMessageAsync(dlqMessage);
-                _unhandledEvents.TryDequeue(out _);
+                _unhandledEvents.TryDequeue(out var unhandledEvent);
+                TestContext.Current.TestOutputHelper!.WriteLine($"Warning: Drained event {unhandledEvent}");
             }
         }
     }

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
@@ -113,13 +113,27 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
         if (syncJob.IsCompletedSuccessfully)
         {
             await cts.CancelAsync();
+            await IgnoreCancellation(getDlqMessage);
             _unhandledEvents.TryDequeue(out _);
+
             return new EventProcessingResult(true, null);
         }
 
         await cts.CancelAsync();
 
         return new EventProcessingResult(false, null);
+    }
+
+    private static async Task IgnoreCancellation(Task task)
+    {
+        try
+        {
+            await task;
+        }
+        catch (TaskCanceledException)
+        {
+            // Ignore
+        }
     }
 
     private SyncCompletionSignal GetSyncJobCompleteSignal()

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
@@ -115,7 +115,7 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
         if (syncJob.IsCompletedSuccessfully)
         {
             await cts.CancelAsync();
-            await IgnoreCancellation(getDlqMessage);
+            await IgnoreCancellation(getDlqMessage, "Got success event");
             _unhandledEvents.TryDequeue(out var handledEvent);
             Log($"Debug: An event was successfully handled {handledEvent}");
 
@@ -123,12 +123,12 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
         }
 
         await cts.CancelAsync();
-        await IgnoreCancellation(getDlqMessage);
+        await IgnoreCancellation(getDlqMessage, "No success or DLQ event");
 
         return new EventProcessingResult(false, null);
     }
 
-    private static async Task IgnoreCancellation(Task task)
+    private static async Task IgnoreCancellation(Task task,  string cancellationReason)
     {
         try
         {
@@ -136,7 +136,7 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
         }
         catch (OperationCanceledException)
         {
-            Log($"Debug: Ignored a task that was cancelled");
+            Log($"Debug: Ignored a task that was cancelled:  {cancellationReason}");
         }
     }
 
@@ -282,23 +282,21 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
 
         return new Arrangement(appId, partyId, instanceCreatedAt, instanceId, dialogId);
     }
-
     /// <summary>
-    /// Drains all remaining messages from the previous test to prevent cross-test contamination.
+    /// Drains all remaining messages off the dlq.
     ///
-    /// After WireMock is reset, any message still being processed will hit 501 → immediate DLQ.
-    /// However, a message sitting in the scheduled state (ScheduleRetryIndefinitely) must wait for
-    /// the emulator's SQL poll cycle before it gets delivered and can 501 → DLQ. That poll can take
-    /// 10–60 s under load. We short-circuit by cancelling scheduled messages directly via their
-    /// sequence numbers, which is instantaneous and bypasses the SQL poll entirely.
-    /// Any message that was actively being processed at reset time still flows → 501 → DLQ normally.
+    /// This is important for isolating each test, so that messages from the previous test doesn't affect the next.
+    /// Draining just the dlq should be sufficient, because we reset the WireMock stubs so all apis return 501.
+    /// This should make any lingering messages go to the dlq.
+    /// The default LockDuration in the service bus is 1 minute.
+    /// Thats why this method should have a generous timeout, in case any messages are locked by another receiver.
     /// </summary>
     private async Task DrainLeftoverMessages()
     {
         if (_unhandledEvents.IsEmpty) return;
         Log("Warning: Found unhandled messages, draining leftover messages");
 
-        var timeoutSeconds = 60;
+        var timeoutSeconds = 120;
         var start = DateTimeOffset.UtcNow;
         await using var dlqReceiver = CreateReceiver();
         while (!_unhandledEvents.IsEmpty)

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
@@ -34,20 +34,22 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
 
     public async ValueTask DisposeAsync()
     {
-        // Dispose asap, so a test doesn't accidentally consume a fallback mapping
-        await AdapterQueueDlqReceiver.DisposeAsync();
+        try
+        {
+            app.DialogportenApi.LogUnhandledRequests(app.App.Logger, "DialogportenApi").ResetAllExceptFallbackMapping();
+            app.RegisterApi.LogUnhandledRequests(app.App.Logger, "RegisterApi").ResetAllExceptFallbackMapping();
+            app.AltinnApi.LogUnhandledRequests(app.App.Logger, "AltinnApi").ResetAllExceptFallbackMapping();
+            app.StorageApi.LogUnhandledRequests(app.App.Logger, "StorageApi").ResetAllExceptFallbackMapping();
 
-        app.DialogportenApi.LogUnhandledRequests(app.App.Logger, "DialogportenApi").ResetAllExceptFallbackMapping();
-        app.RegisterApi.LogUnhandledRequests(app.App.Logger, "RegisterApi").ResetAllExceptFallbackMapping();
-        app.AltinnApi.LogUnhandledRequests(app.App.Logger, "AltinnApi").ResetAllExceptFallbackMapping();
-        app.StorageApi.LogUnhandledRequests(app.App.Logger, "StorageApi").ResetAllExceptFallbackMapping();
-
-        GetSyncJobCompleteSignal().Reset();
-        var clearCache = app.App.Services.GetRequiredService<IFusionCache>().ClearAsync().AsTask();
-        var drainMessages = DrainLeftoverMessages();
-        await Task.WhenAll(clearCache, drainMessages);
-
-        GC.SuppressFinalize(this);
+            GetSyncJobCompleteSignal().Reset();
+            await app.App.Services.GetRequiredService<IFusionCache>().ClearAsync().AsTask();
+            await DrainLeftoverMessages();
+        }
+        finally
+        {
+            await AdapterQueueDlqReceiver.DisposeAsync();
+            GC.SuppressFinalize(this);
+        }
     }
 
     protected async Task<EventProcessingResult> SendAndWait<T>(T command, TimeSpan? timeout = null) where T : notnull
@@ -298,7 +300,6 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
 
         var timeoutSeconds = 120;
         var start = DateTimeOffset.UtcNow;
-        await using var dlqReceiver = CreateReceiver();
         while (!_unhandledEvents.IsEmpty)
         {
             var elapsed = DateTimeOffset.UtcNow - start;
@@ -308,14 +309,14 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
                     $"Unable to drain dql: Timeout after {elapsed} seconds. This invalidates the whole test suite. Look for the test that failed to drain! {_unhandledEvents.Count} undrained messages");
             }
 
-            var dlqMessage = await dlqReceiver.ReceiveMessageAsync(
+            var dlqMessage = await AdapterQueueDlqReceiver.ReceiveMessageAsync(
                 TimeSpan.FromSeconds(timeoutSeconds / 3),
                 TestContext.Current.CancellationToken
             );
 
             if (dlqMessage != null)
             {
-                await dlqReceiver.CompleteMessageAsync(dlqMessage);
+                await AdapterQueueDlqReceiver.CompleteMessageAsync(dlqMessage);
                 _unhandledEvents.TryDequeue(out var unhandledEvent);
                 Log($"Warning: Drained event {unhandledEvent}");
             }

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
@@ -25,13 +25,7 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
 
     public ValueTask InitializeAsync()
     {
-        AdapterQueueDlqReceiver = app.ServiceBusClient.CreateReceiver(
-            Constants.AdapterQueueName,
-            new ServiceBusReceiverOptions
-            {
-                SubQueue = SubQueue.DeadLetter,
-            }
-        );
+        AdapterQueueDlqReceiver = CreateDlqReceiver();
 
         return ValueTask.CompletedTask;
     }
@@ -42,22 +36,20 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
         app.RegisterApi.LogUnhandledRequests(app.App.Logger, "RegisterApi").ResetAllExceptFallbackMapping();
         app.AltinnApi.LogUnhandledRequests(app.App.Logger, "AltinnApi").ResetAllExceptFallbackMapping();
         app.StorageApi.LogUnhandledRequests(app.App.Logger, "StorageApi").ResetAllExceptFallbackMapping();
-
-        app.AppScope.ServiceProvider.GetRequiredService<SyncCompletionSignal>().Reset();
-        await app.App.Services.GetRequiredService<IFusionCache>().ClearAsync();
-        await DrainLeftoverMessages();
         await AdapterQueueDlqReceiver.DisposeAsync();
 
+        await app.App.Services.GetRequiredService<IFusionCache>().ClearAsync();
+        await DrainLeftoverMessages();
         GetSyncJobCompleteSignal().Reset();
 
         GC.SuppressFinalize(this);
     }
 
-    protected async Task<EventProcessingResult> SendAndWait<T>(T command) where T : notnull
+    protected async Task<EventProcessingResult> SendAndWait<T>(T command, TimeSpan? timeout = null) where T : notnull
     {
         _unhandledEvents.Enqueue(command);
         var bus = app.StorageScope.ServiceProvider.GetRequiredService<IMessageBus>();
-        var eventProcessingResult = GetEventProcessingResult();
+        var eventProcessingResult = GetEventProcessingResult(timeout);
         await bus.SendAsync(command);
         return await eventProcessingResult;
     }
@@ -119,6 +111,7 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
             _unhandledEvents.TryDequeue(out _);
             return new EventProcessingResult(true, null);
         }
+
         await cts.CancelAsync();
 
         return new EventProcessingResult(false, null);
@@ -268,16 +261,21 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
     }
 
     /// <summary>
-    /// Drains all remaining messages off the dlq.
+    /// Drains all remaining messages from the previous test to prevent cross-test contamination.
     ///
-    /// This is important for isolating each test, so that messages from the previous test doesn't affect the next.
-    /// Draining just the dlq should be sufficient, because we reset the WireMock stubs so all apis return 501.
-    /// This should make any lingering messages go to the dlq.
+    /// After WireMock is reset, any message still being processed will hit 501 → immediate DLQ.
+    /// However, a message sitting in the scheduled state (ScheduleRetryIndefinitely) must wait for
+    /// the emulator's SQL poll cycle before it gets delivered and can 501 → DLQ. That poll can take
+    /// 10–60 s under load. We short-circuit by cancelling scheduled messages directly via their
+    /// sequence numbers, which is instantaneous and bypasses the SQL poll entirely.
+    /// Any message that was actively being processed at reset time still flows → 501 → DLQ normally.
     /// </summary>
     private async Task DrainLeftoverMessages()
     {
-        var timeoutSeconds = 30;
+        if (_unhandledEvents.IsEmpty) return;
+        var timeoutSeconds = 60;
         var timeoutAt = DateTimeOffset.UtcNow.AddSeconds(timeoutSeconds);
+        await using var dlqReceiver = CreateDlqReceiver();
         while (!_unhandledEvents.IsEmpty)
         {
             if (DateTimeOffset.UtcNow > timeoutAt)
@@ -286,16 +284,27 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
                     $"Unable to drain dql: Timeout after {timeoutSeconds} seconds. This invalidates the whole test suite. Look for the test that failed to drain! {_unhandledEvents.Count} undrained messages");
             }
 
-            var message = await AdapterQueueDlqReceiver.ReceiveMessageAsync(
+            var dlqMessage = await dlqReceiver.ReceiveMessageAsync(
                 TimeSpan.FromMilliseconds(200),
                 TestContext.Current.CancellationToken
             );
 
-            if (message != null)
+            if (dlqMessage != null)
             {
-                await AdapterQueueDlqReceiver.CompleteMessageAsync(message);
+                await dlqReceiver.CompleteMessageAsync(dlqMessage);
                 _unhandledEvents.TryDequeue(out _);
             }
         }
+    }
+
+    private ServiceBusReceiver CreateDlqReceiver()
+    {
+        return app.ServiceBusClient.CreateReceiver(
+            Constants.AdapterQueueName,
+            new ServiceBusReceiverOptions
+            {
+                SubQueue = SubQueue.DeadLetter,
+            }
+        );
     }
 }

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
@@ -26,14 +26,7 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
 
     public ValueTask InitializeAsync()
     {
-        AdapterQueueDlqReceiver = app.ServiceBusClient.CreateReceiver(
-            Constants.AdapterQueueName,
-            new ServiceBusReceiverOptions
-            {
-                SubQueue = SubQueue.DeadLetter,
-                PrefetchCount = 0
-            }
-        );
+        AdapterQueueDlqReceiver = CreateReceiver();
 
         return ValueTask.CompletedTask;
     }
@@ -287,13 +280,7 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
         if (_unhandledEvents.IsEmpty) return;
         var timeoutSeconds = 60;
         var start = DateTimeOffset.UtcNow;
-        await using var dlqReceiver = app.ServiceBusClient.CreateReceiver(
-            Constants.AdapterQueueName,
-            new ServiceBusReceiverOptions
-            {
-                SubQueue = SubQueue.DeadLetter,
-            }
-        );
+        await using var dlqReceiver = CreateReceiver();
         while (!_unhandledEvents.IsEmpty)
         {
             var elapsed = DateTimeOffset.UtcNow - start;
@@ -315,5 +302,17 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
                 TestContext.Current.TestOutputHelper!.WriteLine($"Warning: Drained event {unhandledEvent}");
             }
         }
+    }
+
+    private ServiceBusReceiver CreateReceiver()
+    {
+        return app.ServiceBusClient.CreateReceiver(
+            Constants.AdapterQueueName,
+            new ServiceBusReceiverOptions
+            {
+                SubQueue = SubQueue.DeadLetter,
+                PrefetchCount = 0
+            }
+        );
     }
 }

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/DialogportenAdapterApplication.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/DialogportenAdapterApplication.cs
@@ -66,11 +66,13 @@ public class DialogportenAdapterApplication : IAsyncLifetime
                 .UntilMessageIsLogged("SQL Server is now ready for client connections"))
             .Build();
 
+        string projectRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", ".."));
         var asbImage = "mcr.microsoft.com/azure-messaging/servicebus-emulator@" +
                        "sha256:a00c9626c8960f6b9be6178aa91a7ac8f1a102c0d9deda7603a1ba0ac9d9ab51";
         _asbContainer = new ServiceBusBuilder(asbImage)
             .WithAcceptLicenseAgreement(true)
             .WithName(IsDebug ? "dialogporten-adapter-it-asb" : null)
+            .WithConfig(Path.Combine(projectRoot, "Common", "AzureServiceBusEmulator", "Config.json"))
             .WithReuse(IsDebug)
             .WithMsSqlContainer(_network, _mssqlContainer, networkAlias)
             .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Emulator Service is Successfully Up!"))
@@ -191,6 +193,7 @@ public class DialogportenAdapterApplication : IAsyncLifetime
         builderConfiguration["DialogportenAdapter:Altinn:InternalRegisterEndpoint"] = RegisterApi.Url;
         builderConfiguration["WolverineSettings:ServiceBusConnectionString"] = _asbContainer.GetConnectionString();
         builderConfiguration["WolverineSettings:ManagementConnectionString"] = _asbContainer.GetHttpConnectionString();
+        builderConfiguration["WolverineSettings:ListenerCount"] = "3";
     }
 
     private void SetUpWireMockEndpointsForStartup()

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/DialogportenAdapterApplication.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/DialogportenAdapterApplication.cs
@@ -66,7 +66,7 @@ public class DialogportenAdapterApplication : IAsyncLifetime
                 .UntilMessageIsLogged("SQL Server is now ready for client connections"))
             .Build();
 
-        string projectRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", ".."));
+        var projectRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", ".."));
         var asbImage = "mcr.microsoft.com/azure-messaging/servicebus-emulator@" +
                        "sha256:a00c9626c8960f6b9be6178aa91a7ac8f1a102c0d9deda7603a1ba0ac9d9ab51";
         _asbContainer = new ServiceBusBuilder(asbImage)

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/SyncDialogOnInstanceUpdatedHandlerDlqTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/SyncDialogOnInstanceUpdatedHandlerDlqTest.cs
@@ -195,7 +195,7 @@ public class SyncDialogOnInstanceUpdatedHandlerDlqTest(DialogportenAdapterApplic
             InstanceId: arrangement.InstanceId,
             InstanceCreatedAt: arrangement.InstanceCreatedAt,
             IsMigration: false
-        ), TimeSpan.FromSeconds(5));
+        ), TimeSpan.FromSeconds(6));
 
         // Assert
         result.IsSuccess.Should().BeFalse();

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/SyncDialogOnInstanceUpdatedHandlerDlqTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/SyncDialogOnInstanceUpdatedHandlerDlqTest.cs
@@ -195,7 +195,7 @@ public class SyncDialogOnInstanceUpdatedHandlerDlqTest(DialogportenAdapterApplic
             InstanceId: arrangement.InstanceId,
             InstanceCreatedAt: arrangement.InstanceCreatedAt,
             IsMigration: false
-        ));
+        ), TimeSpan.FromSeconds(5));
 
         // Assert
         result.IsSuccess.Should().BeFalse();


### PR DESCRIPTION
Something caused messages on the queue to be held in lock. Default lock timeout is 1 min. Haven't been able to identify the root cause, but it looks like a combination of changes helped:

- Tune timeouts so they are long enough to catch locked messages
- Reduce lock timeouts via queue config (bonus: we can set more prod-like settings on topics, e.g. RequiresDuplicateDetection=true)
- Reduce wolverine listener count from 50 to 3 for the tests => This may simply have been overloading the emulator
- Add an await on the dlq-checker when it is cancelled => Prevents the dlq-receiver from being accessed by the drain logic before the dlq-checker of the test itself has finished
- PrefetchCount = 0 on dlq receiver => Prevents a test from pulling down more messages than intended

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- https://github.com/Altinn/altinn-dialogporten-adapter/issues/226

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability by centralizing DLQ receiver usage, adding safer teardown, explicit cancellation checks, and consolidating send/wait into a single overload with optional timeout.
  * Enhanced draining strategy: increased total drain budget, faster per-receive attempts, and explicit completion/logging of drained messages.
  * Updated a test to use a bounded 5s wait to avoid unbounded waits.

* **Configuration**
  * Added emulator configuration and adjusted listener concurrency for faster, more reliable test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->