### PR TITLE
Handle long/missing attachment file names

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
@@ -327,7 +327,9 @@ internal sealed class StorageDialogportenDataMerger
             }
 
             var extension = Path.GetExtension(dataElement.Filename);
-            return string.Concat(dataElement.Filename.AsSpan(0, 255 - extension.Length), extension);
+            return extension.Length >= 255
+                ? dataElement.Filename[..255]
+                : string.Concat(dataElement.Filename.AsSpan(0, 255 - extension.Length), extension);
         }
 
         AttachmentDto CreateAttachmentDto(DataElement element)

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
@@ -321,15 +321,15 @@ internal sealed class StorageDialogportenDataMerger
                     : "Navn på vedlegg mangler";
             }
 
-            if (dataElement.Filename.Length <= 255)
+            if (dataElement.Filename.Length <= Constants.DefaultMaxStringLength)
             {
                 return dataElement.Filename;
             }
 
             var extension = Path.GetExtension(dataElement.Filename);
-            return extension.Length >= 255
-                ? dataElement.Filename[..255]
-                : string.Concat(dataElement.Filename.AsSpan(0, 255 - extension.Length), extension);
+            return extension.Length >= Constants.DefaultMaxStringLength
+                ? dataElement.Filename[..Constants.DefaultMaxStringLength]
+                : string.Concat(dataElement.Filename.AsSpan(0, Constants.DefaultMaxStringLength - extension.Length), extension);
         }
 
         AttachmentDto CreateAttachmentDto(DataElement element)

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/StorageDialogportenDataMerger.cs
@@ -312,6 +312,24 @@ internal sealed class StorageDialogportenDataMerger
             !_settings.DialogportenAdapter.Adapter.FeatureFlag
                 .EnableSubmissionTransmissions;
 
+        string GetFileName(DataElement dataElement)
+        {
+            if (string.IsNullOrEmpty(dataElement.Filename))
+            {
+                return !string.IsNullOrEmpty(dataElement.DataType)
+                    ? dataElement.DataType
+                    : "Navn på vedlegg mangler";
+            }
+
+            if (dataElement.Filename.Length <= 255)
+            {
+                return dataElement.Filename;
+            }
+
+            var extension = Path.GetExtension(dataElement.Filename);
+            return string.Concat(dataElement.Filename.AsSpan(0, 255 - extension.Length), extension);
+        }
+
         AttachmentDto CreateAttachmentDto(DataElement element)
         {
             var consumerType = attachmentVisibility.GetConsumerType(element);
@@ -324,7 +342,7 @@ internal sealed class StorageDialogportenDataMerger
             return new()
             {
                 Id = Guid.Parse(element.Id).ToVersion7(element.Created!.Value),
-                DisplayName = [new() { LanguageCode = "nb", Value = element.Filename ?? element.DataType }],
+                DisplayName = [new() { LanguageCode = "nb", Value = GetFileName(element) }],
                 Name = element.DataType,
                 Urls =
                 [
@@ -353,7 +371,7 @@ internal sealed class StorageDialogportenDataMerger
                 // Ensure unique IDs when the same DataElement appears as both TransmissionAttachment and Attachment
                 // This prevents ID collisions that would cause conflicts in Dialogporten
                 Id = transmissionId.CreateDeterministicSubUuidV7(element.Id),
-                DisplayName = [new() { LanguageCode = "nb", Value = element.Filename ?? element.DataType }],
+                DisplayName = [new() { LanguageCode = "nb", Value = GetFileName(element) }],
                 Name = element.DataType,
                 Urls =
                 [
@@ -451,7 +469,7 @@ internal sealed class StorageDialogportenDataMerger
             .Count();
 
         // Count of data elements of ref-data-as-pdf that are generated from a PDF generating task
-        var generatedPdfsCount = dataElements 
+        var generatedPdfsCount = dataElements
             .Count(dataElement =>
                 dataElement.DataType == PdfType &&
                 dataElement.References
@@ -465,7 +483,6 @@ internal sealed class StorageDialogportenDataMerger
 
     private static IEnumerable<(DataElement dataElement, DateTime? created)> RealCreate(MergeDto dto)
     {
-        
         var dataElements = dto.Instance.Data.Where(x => !ShouldSkipDataElement(x)).ToList();
         var dataTypes = dto.Application.DataTypes ?? [];
 

--- a/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/StorageDialogportenDataMergerTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/StorageDialogportenDataMergerTest.cs
@@ -2485,4 +2485,63 @@ public class StorageDialogportenDataMergerTest
             Deleted = false
         });
     }
+
+    [Fact(DisplayName =
+        "Given DataElements with missing or too long filenames, attachment display names fall back to data type or placeholder and are capped at 255 characters")]
+    public async Task Merge_DataElementsWithMissingOrTooLongFilenames_MapsToAttachmentDisplayNamesWithMaxLength()
+    {
+        var mergeDto = new MergeDto(
+            Application: AltinnApplicationBuilder
+                .NewDefaultAltinnApplication()
+                .WithDataTypes(AltinnDataTypeBuilder.NewDefaultDataType().WithId("png-1").Build())
+                .Build(),
+            ApplicationTexts: new ApplicationTexts { Translations = [] },
+            DialogId: Guid.Parse("902de1ba-6919-4355-99ad-7ad279266a2f"),
+            Events: new InstanceEventList
+            {
+                InstanceEvents = [AltinnInstanceEventBuilder.NewCreatedByPlatformUserInstanceEvent(UserId1).Build()]
+            },
+            Instance: AltinnInstanceBuilder
+                .NewInProgressInstance()
+                .WithData([
+                    AltinnDataElementBuilder
+                        .NewDefaultDataElementBuilder()
+                        .WithId("019bd57e-ce5e-74ed-8130-3a1ac8af3d91")
+                        .WithFilename(new string('a', 300) + ".pdf")
+                        .Build(),
+                    AltinnDataElementBuilder
+                        .NewDefaultDataElementBuilder()
+                        .WithId("019bd5eb-4239-7a40-a823-7735059ef136")
+                        .WithFilename(new string('b', 255))
+                        .Build(),
+                    AltinnDataElementBuilder
+                        .NewDefaultDataElementBuilder()
+                        .WithId("019bd5eb-62e2-711d-b79f-835d26cd1a58")
+                        .WithFilename(null!)
+                        .WithDataType("png-1")
+                        .Build(),
+                    AltinnDataElementBuilder
+                        .NewDefaultDataElementBuilder()
+                        .WithId("019bd5eb-97ba-79a8-9f37-3ef8f82b2d0b")
+                        .WithFilename(null!)
+                        .Build(),
+                ])
+                .Build(),
+            ExistingDialog: null,
+            IsMigration: false);
+
+        var actualDialogDto = await _storageDialogportenDataMerger.Merge(mergeDto, currentAttempt: 1, CancellationToken.None);
+
+        var displayNames = actualDialogDto.Attachments
+            .Select(x => x.DisplayName.Single().Value)
+            .ToList();
+
+        displayNames.Should().BeEquivalentTo([
+            new string('a', 251) + ".pdf",
+            new string('b', 255),
+            "png-1",
+            "Navn på vedlegg mangler"
+        ]);
+        displayNames.Should().AllSatisfy(x => x.Length.Should().BeLessThanOrEqualTo(255));
+    }
 }

--- a/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/StorageDialogportenDataMergerTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/StorageDialogportenDataMergerTest.cs
@@ -2525,6 +2525,11 @@ public class StorageDialogportenDataMergerTest
                         .WithId("019bd5eb-97ba-79a8-9f37-3ef8f82b2d0b")
                         .WithFilename(null!)
                         .Build(),
+                    AltinnDataElementBuilder
+                        .NewDefaultDataElementBuilder()
+                        .WithId("019bd5eb-bd4f-7176-948e-79921affe066")
+                        .WithFilename("c." + new string('d', 300))
+                        .Build(),
                 ])
                 .Build(),
             ExistingDialog: null,
@@ -2540,7 +2545,8 @@ public class StorageDialogportenDataMergerTest
             new string('a', 251) + ".pdf",
             new string('b', 255),
             "png-1",
-            "Navn på vedlegg mangler"
+            "Navn på vedlegg mangler",
+            "c." + new string('d', 253)
         ]);
         displayNames.Should().AllSatisfy(x => x.Length.Should().BeLessThanOrEqualTo(255));
     }


### PR DESCRIPTION
## Description
This handles (truncates) very long (>255) filenames as well as empty file names observed in some legacy instances.

## Related Issue(s)
- n/a

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attachment display name handling: truncates names to 255 characters while preserving file extensions and uses fallback labels when filenames are missing.

* **Tests**
  * Added unit test coverage verifying display name truncation, extension preservation, fallback labels, and 255-character limit enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->