### PR TITLE
fix: redact pii

### DIFF
--- a/src/Altinn.DialogportenAdapter.WebApi/Common/FourHundredLoggingDelegatingHandler.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/FourHundredLoggingDelegatingHandler.cs
@@ -35,7 +35,7 @@ internal sealed class FourHundredLoggingDelegatingHandler : DelegatingHandler
         {
             if (ShouldLog(e.StatusCode))
             {
-                _logger.LogRequestError(e, request.Method, request.RequestUri, await requestContent.Value, e.StatusCode, e.Content);
+                _logger.LogRequestError(e, request.Method, request.RequestUri, LogRedactor.Redact(await requestContent.Value), e.StatusCode, LogRedactor.Redact(e.Content));
             }
             throw;
         }
@@ -47,7 +47,7 @@ internal sealed class FourHundredLoggingDelegatingHandler : DelegatingHandler
 
         await response.Content.LoadIntoBufferAsync(cancellationToken);
         var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
-        _logger.Log400Response(request.Method, request.RequestUri, await requestContent.Value, response.StatusCode, responseContent);
+        _logger.Log400Response(request.Method, request.RequestUri, LogRedactor.Redact(await requestContent.Value), response.StatusCode, LogRedactor.Redact(responseContent));
         return response;
     }
 

--- a/src/Altinn.DialogportenAdapter.WebApi/Common/LogRedactor.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/LogRedactor.cs
@@ -1,0 +1,126 @@
+using System.Collections.Frozen;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+
+namespace Altinn.DialogportenAdapter.WebApi.Common;
+
+/// <summary>
+/// Redacts PII from request/response bodies before they are written to the logs by
+/// <see cref="FourHundredLoggingDelegatingHandler"/>.
+/// <para>
+/// To extend the redaction, add a property name to <see cref="RedactedPropertyNames"/> (the whole value is
+/// replaced) or a regex to <see cref="ValuePatterns"/> (matches are masked wherever they appear in a string value).
+/// </para>
+/// </summary>
+internal static partial class LogRedactor
+{
+    private const string Placeholder = "[REDACTED]";
+
+    /// <summary>
+    /// Property names (case-insensitive) whose entire value - string or nested object - is replaced with
+    /// <see cref="Placeholder"/>. Used for free-text fields that may contain names or other personal details.
+    /// </summary>
+    private static readonly FrozenSet<string> RedactedPropertyNames =
+        new[] { "actorName", "title", "summary", "senderName", "additionalInfo" }
+            .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Patterns applied to every string value. The URN patterns keep their prefix and mask only the identifier,
+    /// so logs still show what kind of value was redacted.
+    /// </summary>
+    private static readonly (Regex Pattern, string Replacement)[] ValuePatterns =
+    [
+        (PersonIdentifierUrn(), $"${{1}}{Placeholder}"),
+        (LegacySelfIdentifiedUrn(), $"${{1}}{Placeholder}"),
+        (DisplayNameUrn(), $"${{1}}{Placeholder}"),
+        (BareNorwegianIdentifier(), Placeholder),
+    ];
+
+    public static string? Redact(string? content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return content;
+        }
+
+        JsonNode? node;
+        try
+        {
+            node = JsonNode.Parse(content);
+        }
+        catch (JsonException)
+        {
+            // Not JSON (e.g. a plain-text error body) - still mask identifier patterns best-effort.
+            return RedactString(content);
+        }
+
+        if (node is null)
+        {
+            return content;
+        }
+
+        RedactNode(node);
+        return node.ToJsonString();
+    }
+
+    private static void RedactNode(JsonNode node)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+                // Snapshot keys first since we mutate the object while iterating.
+                foreach (var key in obj.Select(x => x.Key).ToArray())
+                {
+                    if (RedactedPropertyNames.Contains(key))
+                    {
+                        obj[key] = Placeholder;
+                    }
+                    else if (obj[key] is { } child)
+                    {
+                        RedactNode(child);
+                    }
+                }
+                break;
+            case JsonArray array:
+                foreach (var item in array)
+                {
+                    if (item is not null)
+                    {
+                        RedactNode(item);
+                    }
+                }
+                break;
+            case JsonValue value when value.TryGetValue<string>(out var str):
+                var redacted = RedactString(str);
+                if (!ReferenceEquals(redacted, str))
+                {
+                    value.ReplaceWith(redacted);
+                }
+                break;
+        }
+    }
+
+    private static string RedactString(string value)
+    {
+        var result = value;
+        foreach (var (pattern, replacement) in ValuePatterns)
+        {
+            result = pattern.Replace(result, replacement);
+        }
+
+        return result;
+    }
+
+    [GeneratedRegex(@"(urn:altinn:person:identifier-no:)[^""\s/]+", RegexOptions.IgnoreCase)]
+    private static partial Regex PersonIdentifierUrn();
+
+    [GeneratedRegex(@"(urn:altinn:person:legacy-selfidentified:)[^""\s/]+", RegexOptions.IgnoreCase)]
+    private static partial Regex LegacySelfIdentifiedUrn();
+
+    [GeneratedRegex(@"(urn:altinn:displayName:)[^""\s/]+", RegexOptions.IgnoreCase)]
+    private static partial Regex DisplayNameUrn();
+
+    [GeneratedRegex(@"\b\d{11}\b")]
+    private static partial Regex BareNorwegianIdentifier();
+}

--- a/tests/Altinn.DialogportenAdapter.Unit.Tests/Common/LogRedactorTests.cs
+++ b/tests/Altinn.DialogportenAdapter.Unit.Tests/Common/LogRedactorTests.cs
@@ -1,0 +1,132 @@
+using System.Text.Json.Nodes;
+using Altinn.DialogportenAdapter.WebApi.Common;
+using AwesomeAssertions;
+
+namespace Altinn.DialogportenAdapter.Unit.Tests.Common;
+
+public class LogRedactorTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Redact_NullOrWhitespace_ReturnsUnchanged(string? input)
+    {
+        LogRedactor.Redact(input).Should().Be(input);
+    }
+
+    [Fact]
+    public void Redact_PersonUrnInParty_MasksIdentifierKeepsPrefix()
+    {
+        const string json = """{"party":"urn:altinn:person:identifier-no:12018212345"}""";
+
+        var result = LogRedactor.Redact(json);
+
+        result.Should().Contain("urn:altinn:person:identifier-no:[REDACTED]");
+        result.Should().NotContain("12018212345");
+    }
+
+    [Fact]
+    public void Redact_PersonUrnInActorId_MasksIdentifier()
+    {
+        const string json = """{"sender":{"actorId":"urn:altinn:person:identifier-no:01017012345"}}""";
+
+        LogRedactor.Redact(json).Should().NotContain("01017012345");
+    }
+
+    [Theory]
+    [InlineData("urn:altinn:organization:identifier-no:912345678")]
+    [InlineData("urn:altinn:party:id:51234")]
+    public void Redact_NonPersonParty_LeftIntact(string party)
+    {
+        var json = $$"""{"party":"{{party}}"}""";
+
+        LogRedactor.Redact(json).Should().Contain(party);
+    }
+
+    [Fact]
+    public void Redact_LegacySelfIdentifiedAndDisplayNameUrns_AreMasked()
+    {
+        const string json = """{"a":"urn:altinn:person:legacy-selfidentified:Per","b":"urn:altinn:displayName:Ola Nordmann"}""";
+
+        var result = LogRedactor.Redact(json);
+
+        result.Should().Contain("urn:altinn:person:legacy-selfidentified:[REDACTED]");
+        result.Should().Contain("urn:altinn:displayName:[REDACTED]");
+        result.Should().NotContain("Per");
+    }
+
+    [Theory]
+    [InlineData("actorName")]
+    [InlineData("title")]
+    [InlineData("summary")]
+    [InlineData("senderName")]
+    [InlineData("additionalInfo")]
+    public void Redact_FreeTextStringField_FullyRedacted(string property)
+    {
+        var json = $$"""{"{{property}}":"Ola Nordmann lives at Storgata 1"}""";
+
+        var node = JsonNode.Parse(LogRedactor.Redact(json)!)!;
+
+        node[property]!.GetValue<string>().Should().Be("[REDACTED]");
+    }
+
+    [Fact]
+    public void Redact_ContentValueObjectFields_ReplacedWholesale()
+    {
+        // title/summary are ContentValueDto objects, not plain strings.
+        const string json = """
+            {"content":{"title":{"value":[{"value":"Sensitive name","languageCode":"nb"}],"mediaType":"text/plain"},
+            "summary":{"value":[{"value":"Sensitive summary","languageCode":"nb"}]}}}
+            """;
+
+        var content = JsonNode.Parse(LogRedactor.Redact(json)!)!["content"]!;
+
+        content["title"]!.GetValue<string>().Should().Be("[REDACTED]");
+        content["summary"]!.GetValue<string>().Should().Be("[REDACTED]");
+        LogRedactor.Redact(json).Should().NotContain("Sensitive");
+    }
+
+    [Fact]
+    public void Redact_NestedTransmissionsAndActivities_MaskActorIds()
+    {
+        const string json = """
+            {"transmissions":[{"sender":{"actorId":"urn:altinn:person:identifier-no:02027012345"}}],
+            "activities":[{"performedBy":{"actorId":"urn:altinn:person:identifier-no:03037012345"}}]}
+            """;
+
+        var result = LogRedactor.Redact(json);
+
+        result.Should().NotContain("02027012345");
+        result.Should().NotContain("03037012345");
+    }
+
+    [Fact]
+    public void Redact_BareIdentifierInUnlistedField_IsMasked()
+    {
+        const string json = """{"externalReference":"ref-04047012345-x"}""";
+
+        LogRedactor.Redact(json).Should().NotContain("04047012345");
+    }
+
+    [Fact]
+    public void Redact_NonJsonBodyWithIdentifier_StillMasked()
+    {
+        const string text = "Error: party urn:altinn:person:identifier-no:05057012345 not found";
+
+        var result = LogRedactor.Redact(text);
+
+        result.Should().NotContain("05057012345");
+        result.Should().Contain("urn:altinn:person:identifier-no:[REDACTED]");
+    }
+
+    [Fact]
+    public void Redact_PiiFreeJson_RemainsEquivalent()
+    {
+        const string json = """{"org":"ttd","serviceResource":"urn:altinn:resource:app_ttd_test","progress":50}""";
+
+        var result = LogRedactor.Redact(json);
+
+        JsonNode.DeepEquals(JsonNode.Parse(result!), JsonNode.Parse(json)).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Description
This removes PII from ending up in exception logs

## Related Issue(s)
- n/a

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive personal information is now automatically redacted from application logs, including request and response bodies. This prevents accidental exposure of personally identifiable information during troubleshooting and monitoring activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->