### PR TITLE
feat: Use timezone for receipt from the Prefer header if supplied.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0.203@sha256:8a90a473da5205a16979de99d2fc20975e922c68304f5c79d564e666dc3982fc AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.400@sha256:e1fc6e423f543119c406d24e2e687d67c569f18f04a37a8b0005d80ad0dcee80 AS build
 WORKDIR /app
 
 COPY ["Directory.Build.props", "."]
@@ -15,7 +15,7 @@ COPY src ./src
 RUN dotnet build -c Release -o out ./src/Altinn.DialogportenAdapter.WebApi/Altinn.DialogportenAdapter.WebApi.csproj
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.10@sha256:bab27d29d13f9e903442c5fe83d7e162013747c6a101850f21049d17248afb85 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.11@sha256:282c2e90dd35c6a720b744f4848d3dce9de4bfb404011270cc8ee63f07e56c36 AS final
 WORKDIR /app
 EXPOSE 5011
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.301",
+    "version": "10.0.302",
     "rollForward": "disable"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.301",
+    "version": "10.0.400",
     "rollForward": "disable"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.302",
+    "version": "10.0.301",
     "rollForward": "disable"
   }
 }

--- a/src/Altinn.DialogportenAdapter.Contracts/Altinn.DialogportenAdapter.Contracts.csproj
+++ b/src/Altinn.DialogportenAdapter.Contracts/Altinn.DialogportenAdapter.Contracts.csproj
@@ -2,7 +2,7 @@
 
     <ItemGroup>
         <PackageReference Include="AsyncKeyedLock" Version="8.0.2" />
-        <PackageReference Include="WolverineFx.AzureServiceBus" Version="5.39.3" />
+        <PackageReference Include="WolverineFx.AzureServiceBus" Version="5.40.1" />
     </ItemGroup>
 
 </Project>

--- a/src/Altinn.DialogportenAdapter.EventSimulator/Altinn.DialogportenAdapter.EventSimulator.csproj
+++ b/src/Altinn.DialogportenAdapter.EventSimulator/Altinn.DialogportenAdapter.EventSimulator.csproj
@@ -8,11 +8,11 @@
       <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
       <PackageReference Include="Refit.HttpClientFactory" Version="10.2.0" />
       <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="10.1.0" />
-      <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+      <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
       <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
       <PackageReference Include="Azure.Identity" Version="1.21.0" />
       <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.5.0" />
-      <PackageReference Include="WolverineFx.AzureServiceBus" Version="5.39.3" />
+      <PackageReference Include="WolverineFx.AzureServiceBus" Version="5.40.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Altinn.DialogportenAdapter.EventSimulator/Dockerfile
+++ b/src/Altinn.DialogportenAdapter.EventSimulator/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0.203@sha256:8a90a473da5205a16979de99d2fc20975e922c68304f5c79d564e666dc3982fc AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.400@sha256:e1fc6e423f543119c406d24e2e687d67c569f18f04a37a8b0005d80ad0dcee80 AS build
 WORKDIR /app
 
 COPY ["Directory.Build.props", "."]
@@ -15,7 +15,7 @@ COPY src ./src
 RUN dotnet build -c Release -o out ./src/Altinn.DialogportenAdapter.EventSimulator/Altinn.DialogportenAdapter.EventSimulator.csproj
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.9@sha256:ddcf70ad1ab963a4fcd41fbd722a6b660e404e87567cfbd46fd2809c21b02088 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.11@sha256:282c2e90dd35c6a720b744f4848d3dce9de4bfb404011270cc8ee63f07e56c36 AS final
 WORKDIR /app
 EXPOSE 5012
 

--- a/src/Altinn.DialogportenAdapter.WebApi/Altinn.DialogportenAdapter.WebApi.csproj
+++ b/src/Altinn.DialogportenAdapter.WebApi/Altinn.DialogportenAdapter.WebApi.csproj
@@ -7,9 +7,8 @@
         <PackageReference Include="Altinn.Platform.Storage.Interface" Version="4.7.1" />
         <PackageReference Include="Azure.Identity" Version="1.21.0" />
         <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.6.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
-        <PackageReference Include="Microsoft.OpenApi" Version="2.11.0"/> <!-- Forced upgrade to patch https://github.com/advisories/GHSA-v5pm-xwqc-g5wc. Remove this when Microsoft.AspNetCore.OpenApi is patched. -->
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
         <PackageReference Include="Refit.HttpClientFactory" Version="10.2.0" />
         <PackageReference Include="DeterministicGuids" Version="1.0.11" />
         <PackageReference Include="WolverineFx.AzureServiceBus" Version="5.40.1" />

--- a/src/Altinn.DialogportenAdapter.WebApi/Altinn.DialogportenAdapter.WebApi.csproj
+++ b/src/Altinn.DialogportenAdapter.WebApi/Altinn.DialogportenAdapter.WebApi.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <ItemGroup>
-        <PackageReference Include="Altinn.ApiClients.Dialogporten" Version="1.117.0" />
+        <PackageReference Include="Altinn.ApiClients.Dialogporten" Version="1.118.0" />
         <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="10.1.0" />
         <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
         <PackageReference Include="Altinn.Platform.Storage.Interface" Version="4.7.1" />
         <PackageReference Include="Azure.Identity" Version="1.21.0" />
-        <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.5.0" />
+        <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.6.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
-        <PackageReference Include="Microsoft.OpenApi" Version="2.11.0" />
+        <PackageReference Include="Microsoft.OpenApi" Version="2.11.0"/> <!-- Forced upgrade to patch https://github.com/advisories/GHSA-v5pm-xwqc-g5wc. Remove this when Microsoft.AspNetCore.OpenApi is patched. -->
         <PackageReference Include="Refit.HttpClientFactory" Version="10.2.0" />
         <PackageReference Include="DeterministicGuids" Version="1.0.11" />
-        <PackageReference Include="WolverineFx.AzureServiceBus" Version="5.39.3" />
+        <PackageReference Include="WolverineFx.AzureServiceBus" Version="5.40.1" />
         <PackageReference Include="ZiggyCreatures.FusionCache.Locking.AsyncKeyed" Version="2.6.0" />
     </ItemGroup>
 

--- a/src/Altinn.DialogportenAdapter.WebApi/Common/Extensions/WebApplicationExtensions.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/Extensions/WebApplicationExtensions.cs
@@ -1,0 +1,141 @@
+using Altinn.DialogportenAdapter.Contracts;
+using Altinn.DialogportenAdapter.WebApi.Features.Command.Delete;
+using Altinn.DialogportenAdapter.WebApi.Features.Command.Sync;
+using Altinn.DialogportenAdapter.WebApi.Infrastructure.Storage;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace Altinn.DialogportenAdapter.WebApi.Common.Extensions;
+
+public static class WebApplicationExtensions
+{
+    extension(WebApplication app)
+    {
+        public WebApplication RegisterRoutes()
+        {
+            app.UseHttpsRedirection()
+                .UseCors()
+                .UseAuthentication()
+                .UseAuthorization();
+
+            var baseRoute = app.MapGroup("storage/dialogporten");
+            var v1Route = baseRoute.MapGroup("api/v1");
+            var settings = app.Services.GetRequiredService<IOptions<Settings>>().Value;
+
+            app.MapHealthChecks("/health")
+                .AllowAnonymous();
+
+            app.MapOpenApi()
+                .AllowAnonymous();
+
+            v1Route.MapPost("syncDialog", async (
+                    [FromBody] SyncInstanceCommand request,
+                    [FromServices] ISyncInstanceToDialogService syncService,
+                    CancellationToken cancellationToken) =>
+                {
+                    await syncService.Sync(request, cancellationToken: cancellationToken);
+                    return Results.NoContent();
+                })
+                .RequireAuthorization();
+
+            v1Route.MapPost("syncDialog/simple/{partyId}/{instanceGuid:guid}", async (
+                    [FromRoute] string partyId,
+                    [FromRoute] Guid instanceGuid,
+                    [FromQuery] bool? isMigration,
+                    [FromServices] ISyncInstanceToDialogService syncService,
+                    [FromServices] IStorageApi storageApi,
+                    CancellationToken cancellationToken) =>
+                {
+                    var instance = await storageApi
+                        .GetInstance(partyId, instanceGuid, cancellationToken)
+                        .ContentOrDefault();
+                    if (instance is null)
+                    {
+                        return Results.NotFound();
+                    }
+
+                    var request = new SyncInstanceCommand(instance.AppId, partyId, instanceGuid,
+                        instance.Created!.Value, isMigration ?? false);
+                    await syncService.Sync(request, cancellationToken: cancellationToken);
+                    return Results.NoContent();
+                })
+                .RequireAuthorization()
+                .ExcludeFromDescription();
+
+            v1Route.MapDelete("instance/{instanceOwner}/{instanceGuid:guid}", async (
+                    [FromRoute] string instanceOwner,
+                    [FromRoute] Guid instanceGuid,
+                    [FromHeader(Name = "Authorization")] string authorization,
+                    [FromServices] InstanceService instanceService,
+                    CancellationToken cancellationToken) =>
+                {
+                    var request = new DeleteInstanceDto(instanceOwner, instanceGuid, authorization);
+                    return await instanceService.Delete(request, cancellationToken) switch
+                    {
+                        DeleteResponse.Success => Results.NoContent(),
+                        DeleteResponse.UnAuthorized => Results.Unauthorized(),
+                        DeleteResponse.NotFound => Results.NotFound(),
+                        DeleteResponse.NotDeletableYet notYet => Results.Problem(
+                            type: "urn:altinn:problem:minimum-persistence-lifetime-not-satisfied",
+                            title: "Deletion not allowed during minimum persistence lifetime period",
+                            statusCode: StatusCodes.Status422UnprocessableEntity,
+                            detail:
+                            "The instance cannot be deleted yet because it is still within the configured minimum persistence lifetime period after archiving.",
+                            instance:
+                            $"{settings.DialogportenAdapter.Altinn.GetPlatformUri()}instance/{instanceOwner}/{instanceGuid}",
+                            extensions: new Dictionary<string, object?>
+                            {
+                                ["archivedAt"] = notYet.ArchivedAt.ToString("O"),
+                                ["gracePeriodDays"] = notYet.GracePeriod,
+                                ["deletionAllowedAt"] = notYet.DeletionAllowedAt.ToString("O")
+                            }
+                        ),
+                        _ => Results.InternalServerError()
+                    };
+                })
+                .AllowAnonymous(); // 👈 Dialog token is validated inside InstanceService
+
+            v1Route.MapGet("receipt/{dialogId:guid}/{transactionId:guid}", async (
+                    [FromRoute] Guid dialogId,
+                    [FromRoute] Guid transactionId,
+                    [FromQuery(Name = "lang")] string? languageCode,
+                    [FromHeader(Name = "Authorization")] string authorization,
+                    [FromHeader(Name = "Prefer")] string? prefer,
+                    [FromServices] InstanceReceipt service,
+                    [FromServices] AuthorizationValidator validator,
+                    CancellationToken cancellationToken) =>
+                {
+                    if (!validator.ValidateDialogToken(authorization, dialogId, ["read"]))
+                        return Results.Unauthorized();
+
+                    var request = new GetReceiptDto(dialogId, transactionId, languageCode, prefer);
+                    var receipt = service.GetReceipt(request, cancellationToken);
+                    return await receipt switch
+                    {
+                        GetReceiptResponse.Success success => Results.Text(success.Markdown, MediaTypes.Markdown),
+                        GetReceiptResponse.NotFound => Results.NotFound(),
+                        GetReceiptResponse.InvalidLanguageCode => Results.ValidationProblem(
+                            new Dictionary<string, string[]>
+                            {
+                                ["lang"] =
+                                [
+                                    $"Expected one of these language codes: {InstanceReceipt.GetSupportedLanguageCodes()}"
+                                ]
+                            }),
+                        GetReceiptResponse.InvalidTimeZone => Results.ValidationProblem(
+                            new Dictionary<string, string[]>
+                            {
+                                ["timezone"] =
+                                [
+                                    "Timezone must be in the INTL format. E.g Europe/Oslo"
+                                ]
+                            }),
+                        _ => Results.InternalServerError()
+                    };
+                })
+                .AllowAnonymous();
+
+            return app;
+        }
+    }
+}

--- a/src/Altinn.DialogportenAdapter.WebApi/Common/http/HttpPreferences.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/http/HttpPreferences.cs
@@ -12,9 +12,9 @@ public sealed class HttpPreferences() : Dictionary<string, string>(StringCompare
 
         foreach (var item in preferences)
         {
-            var parts = item.Split("=");
-            var key = parts.ElementAtOrDefault(0)?.Trim();
-            var value = parts.ElementAtOrDefault(1)?.Trim();
+            var parts = item.Split("=").Select(x => x.Trim()).ToArray();
+            var key = parts.ElementAtOrDefault(0);
+            var value = parts.ElementAtOrDefault(1);
 
             if (string.IsNullOrEmpty(key)) continue;
             if (string.IsNullOrEmpty(value)) continue;

--- a/src/Altinn.DialogportenAdapter.WebApi/Common/http/HttpPreferences.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Common/http/HttpPreferences.cs
@@ -1,0 +1,34 @@
+namespace Altinn.DialogportenAdapter.WebApi.Common.http;
+
+public sealed class HttpPreferences() : Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+{
+    public static HttpPreferences FromHeader(string? headerValue)
+    {
+        if (string.IsNullOrEmpty(headerValue)) return new HttpPreferences();
+
+        var map = new HttpPreferences();
+
+        var preferences = headerValue.Split(",").Select(x => x.Trim()).ToArray();
+
+        foreach (var item in preferences)
+        {
+            var parts = item.Split("=");
+            var key = parts.ElementAtOrDefault(0)?.Trim();
+            var value = parts.ElementAtOrDefault(1)?.Trim();
+
+            if (string.IsNullOrEmpty(key)) continue;
+            if (string.IsNullOrEmpty(value)) continue;
+
+            map[key] = value;
+        }
+
+        return map;
+    }
+
+    public TimeZoneInfo? GetTimeZoneOrDefault()
+    {
+        return TryGetValue("timezone", out var timezone)
+            ? TimeZoneInfo.FindSystemTimeZoneById(timezone)
+            : null;
+    }
+}

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/InstanceReceipt.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/InstanceReceipt.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
 using Altinn.DialogportenAdapter.WebApi.Common.Extensions;
+using Altinn.DialogportenAdapter.WebApi.Common.http;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Register;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Storage;
@@ -12,7 +13,9 @@ namespace Altinn.DialogportenAdapter.WebApi.Features.Command.Sync;
 internal sealed record GetReceiptDto(
     Guid DialogId,
     Guid TransmissionId,
-    string? LanguageCode);
+    string? LanguageCode,
+    string? Prefer
+);
 
 public abstract record GetReceiptResponse
 {
@@ -21,6 +24,7 @@ public abstract record GetReceiptResponse
     public sealed record NotFound : GetReceiptResponse;
 
     public sealed record InvalidLanguageCode : GetReceiptResponse;
+    public sealed record InvalidTimeZone : GetReceiptResponse;
 }
 
 internal sealed partial class InstanceReceipt(
@@ -40,7 +44,7 @@ internal sealed partial class InstanceReceipt(
     private readonly ILogger<InstanceReceipt> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
     private const string DefaultLanguageCode = "nb";
-    private const string InstanceReceiptSummaryKey = "receipt-transmission-summary";
+    public const string InstanceReceiptSummaryKey = "receipt-transmission-summary";
 
     private static readonly List<string> LanguageCodes = ["nb", "nn", "en"];
 
@@ -53,6 +57,18 @@ internal sealed partial class InstanceReceipt(
     {
         if (request.LanguageCode is not null && !LanguageCodes.Contains(request.LanguageCode))
             return new GetReceiptResponse.InvalidLanguageCode();
+
+        var preferences = HttpPreferences.FromHeader(request.Prefer);
+        TimeZoneInfo? timeZone;
+        try
+        {
+            timeZone = preferences.GetTimeZoneOrDefault();
+        }
+        catch
+        {
+            return new GetReceiptResponse.InvalidTimeZone();
+        }
+
 
         var dialog = await _dialogportenApi.Get(request.DialogId, cancellationToken).ContentOrDefault();
         if (dialog is null)
@@ -84,10 +100,8 @@ internal sealed partial class InstanceReceipt(
         var orgs = await _altinnOrgs.GetAltinnOrgs(cancellationToken);
 
         var langCode = request.LanguageCode ?? DefaultLanguageCode;
-        // Time always in Oslo timezone
-        var createdAt = transmission.CreatedAt
-            .ToLocalTime()
-            .ToString("dd.MM.yyyy / HH:mm", CultureInfo.InvariantCulture);
+
+        var createdAt = GetCreatedAt(transmission.CreatedAt, timeZone);
         var sender = await GetSender(dialog.Party, cancellationToken);
         // Return dialog.Org if AltinnOrgs is not responding
         var receiver = orgs is null ? dialog.Org : GetReceiverName(orgs, dialog.Org, langCode);
@@ -107,6 +121,15 @@ internal sealed partial class InstanceReceipt(
              {summary}
              """;
         return new GetReceiptResponse.Success(receipt);
+    }
+
+    private static string GetCreatedAt(DateTimeOffset transmissionCreatedAt, TimeZoneInfo? timeZoneInfo)
+    {
+        var time = timeZoneInfo == null
+            ? transmissionCreatedAt
+            : TimeZoneInfo.ConvertTime(transmissionCreatedAt, timeZoneInfo);
+
+        return time.ToString("dd.MM.yyyy / HH:mm", CultureInfo.InvariantCulture);
     }
 
     private static string GetReceiverName(AltinnOrgData orgs, string orgCode, string languageCode)

--- a/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/InstanceReceipt.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Features/Command/Sync/InstanceReceipt.cs
@@ -51,6 +51,9 @@ internal sealed partial class InstanceReceipt(
     [LoggerMessage(LogLevel.Error, "Unhandled error occured: {Message}")]
     private partial void LogReceiptError(string message);
 
+    [LoggerMessage(LogLevel.Warning, "Error when parsing timezone: {Message}. Prefer header was: {PreferHeader}")]
+    private partial void LogTimeZoneWarning(string message, string? preferHeader);
+
     public static string GetSupportedLanguageCodes() => string.Join(", ", LanguageCodes);
 
     public async Task<GetReceiptResponse> GetReceipt(GetReceiptDto request, CancellationToken cancellationToken)
@@ -64,9 +67,10 @@ internal sealed partial class InstanceReceipt(
         {
             timeZone = preferences.GetTimeZoneOrDefault();
         }
-        catch
+        catch (Exception e)
         {
-            return new GetReceiptResponse.InvalidTimeZone();
+            LogTimeZoneWarning(e.Message, request.Prefer);
+            timeZone = null;
         }
 
 

--- a/src/Altinn.DialogportenAdapter.WebApi/Program.cs
+++ b/src/Altinn.DialogportenAdapter.WebApi/Program.cs
@@ -1,13 +1,7 @@
 using System.Globalization;
-using Altinn.DialogportenAdapter.Contracts;
 using Altinn.DialogportenAdapter.WebApi;
 using Altinn.DialogportenAdapter.WebApi.Common;
 using Altinn.DialogportenAdapter.WebApi.Common.Extensions;
-using Altinn.DialogportenAdapter.WebApi.Features.Command.Delete;
-using Altinn.DialogportenAdapter.WebApi.Features.Command.Sync;
-using Altinn.DialogportenAdapter.WebApi.Infrastructure.Storage;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
 
 // Workaround issue in Wolverine on nb_NB causing intermittent 400 Bad Request errors due to
 // attempts to auto-provision queues with a unicode negative sign
@@ -50,112 +44,9 @@ static void BuildAndRun(string[] args)
         .ConfigureDialogportenAdapterServices(builder.Configuration, builder.Environment, new Clock())
         .ReplaceLocalDevelopmentResources(builder.Configuration, builder.Environment);
 
-    using var app = builder.Build();
-
-    app.UseHttpsRedirection()
-        .UseCors()
-        .UseAuthentication()
-        .UseAuthorization();
-
-    var baseRoute = app.MapGroup("storage/dialogporten");
-    var v1Route = baseRoute.MapGroup("api/v1");
-    var settings = app.Services.GetRequiredService<IOptions<Settings>>().Value;
-
-    app.MapHealthChecks("/health")
-        .AllowAnonymous();
-
-    app.MapOpenApi()
-        .AllowAnonymous();
-
-    v1Route.MapPost("syncDialog", async (
-        [FromBody] SyncInstanceCommand request,
-        [FromServices] ISyncInstanceToDialogService syncService,
-        CancellationToken cancellationToken) =>
-    {
-        await syncService.Sync(request, cancellationToken: cancellationToken);
-        return Results.NoContent();
-    })
-    .RequireAuthorization();
-
-    v1Route.MapPost("syncDialog/simple/{partyId}/{instanceGuid:guid}", async (
-            [FromRoute] string partyId,
-            [FromRoute] Guid instanceGuid,
-            [FromQuery] bool? isMigration,
-            [FromServices] ISyncInstanceToDialogService syncService,
-            [FromServices] IStorageApi storageApi,
-            CancellationToken cancellationToken) =>
-        {
-            var instance = await storageApi
-                .GetInstance(partyId, instanceGuid, cancellationToken)
-                .ContentOrDefault();
-            if (instance is null)
-            {
-                return Results.NotFound();
-            }
-
-            var request = new SyncInstanceCommand(instance.AppId, partyId, instanceGuid, instance.Created!.Value, isMigration ?? false);
-            await syncService.Sync(request, cancellationToken: cancellationToken);
-            return Results.NoContent();
-        })
-        .RequireAuthorization()
-        .ExcludeFromDescription();
-
-    v1Route.MapDelete("instance/{instanceOwner}/{instanceGuid:guid}", async (
-            [FromRoute] string instanceOwner,
-            [FromRoute] Guid instanceGuid,
-            [FromHeader(Name = "Authorization")] string authorization,
-            [FromServices] InstanceService instanceService,
-            CancellationToken cancellationToken) =>
-        {
-            var request = new DeleteInstanceDto(instanceOwner, instanceGuid, authorization);
-            return await instanceService.Delete(request, cancellationToken) switch
-            {
-                DeleteResponse.Success => Results.NoContent(),
-                DeleteResponse.UnAuthorized => Results.Unauthorized(),
-                DeleteResponse.NotFound => Results.NotFound(),
-                DeleteResponse.NotDeletableYet notYet => Results.Problem(
-                    type: "urn:altinn:problem:minimum-persistence-lifetime-not-satisfied",
-                    title: "Deletion not allowed during minimum persistence lifetime period",
-                    statusCode: StatusCodes.Status422UnprocessableEntity,
-                    detail: "The instance cannot be deleted yet because it is still within the configured minimum persistence lifetime period after archiving.",
-                    instance: $"{settings.DialogportenAdapter.Altinn.GetPlatformUri()}instance/{instanceOwner}/{instanceGuid}",
-                    extensions: new Dictionary<string, object?>
-                    {
-                        ["archivedAt"] = notYet.ArchivedAt.ToString("O"),
-                        ["gracePeriodDays"] = notYet.GracePeriod,
-                        ["deletionAllowedAt"] = notYet.DeletionAllowedAt.ToString("O")
-                    }
-                ),
-                _ => Results.InternalServerError()
-            };
-        })
-        .AllowAnonymous(); // 👈 Dialog token is validated inside InstanceService
-
-    v1Route.MapGet("receipt/{dialogId:guid}/{transactionId:guid}", async (
-            [FromRoute] Guid dialogId,
-            [FromRoute] Guid transactionId,
-            [FromQuery(Name = "lang")] string? languageCode,
-            [FromHeader(Name = "Authorization")] string authorization,
-            [FromServices] InstanceReceipt service,
-            [FromServices] AuthorizationValidator validator,
-            CancellationToken cancellationToken) =>
-        {
-            if (!validator.ValidateDialogToken(authorization, dialogId, ["read"]))
-                return Results.Unauthorized();
-
-            var request = new GetReceiptDto(dialogId, transactionId, languageCode);
-            return await service.GetReceipt(request, cancellationToken) switch
-            {
-                GetReceiptResponse.Success success => Results.Text(success.Markdown, MediaTypes.Markdown),
-                GetReceiptResponse.NotFound => Results.NotFound(),
-                GetReceiptResponse.InvalidLanguageCode => Results.ValidationProblem(new Dictionary<string, string[]>
-                {
-                    ["lang"] = [$"Expected one of these language codes: {InstanceReceipt.GetSupportedLanguageCodes()}"]
-                }),
-                _ => Results.InternalServerError()
-            };
-        })
-        .AllowAnonymous();
+    using var app = builder
+        .Build()
+        .RegisterRoutes();
 
     app.Run();
 }

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Altinn.DialogportenAdapter.Integration.Tests.csproj
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Altinn.DialogportenAdapter.Integration.Tests.csproj
@@ -8,11 +8,12 @@
 
   <ItemGroup>
     <PackageReference Include="Altinn.ApiClients.Dialogporten" Version="1.118.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Scrutor" Version="7.0.0" />
-    <PackageReference Include="Testcontainers.ServiceBus" Version="4.12.0" />
+    <PackageReference Include="Testcontainers.ServiceBus" Version="4.13.0" />
+    <PackageReference Include="SSH.NET" Version="2026.0.0" /> <!-- Transient from Testcontainers.ServiceBus. Forced upgrade due to CVE. Remove when patched -->
     <PackageReference Include="WireMock.Net" Version="2.14.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="coverlet.collector" Version="10.0.1" />

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Altinn.DialogportenAdapter.Integration.Tests.csproj
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Altinn.DialogportenAdapter.Integration.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Altinn.ApiClients.Dialogporten" Version="1.117.0" />
+    <PackageReference Include="Altinn.ApiClients.Dialogporten" Version="1.118.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/BaseAdapterIntegrationTest.cs
@@ -80,6 +80,11 @@ public abstract class BaseAdapterIntegrationTest(DialogportenAdapterApplication 
         return message;
     }
 
+    protected string GetHostUri()
+    {
+        return app.App.Urls.First();
+    }
+
     protected record EventProcessingResult(bool IsSuccess, ServiceBusReceivedMessage? DlqMessage)
     {
         public void ShouldBeSuccessful()

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/DialogportenAdapterApplication.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/DialogportenAdapterApplication.cs
@@ -1,9 +1,11 @@
 using System.Globalization;
 using System.Net;
+using Altinn.ApiClients.Dialogporten;
 using Altinn.ApiClients.Maskinporten.Interfaces;
 using Altinn.DialogportenAdapter.Contracts;
 using Altinn.DialogportenAdapter.Integration.Tests.Common.Extensions;
 using Altinn.DialogportenAdapter.Integration.Tests.Common.Services;
+using Altinn.DialogportenAdapter.Integration.Tests.Common.Token;
 using Altinn.DialogportenAdapter.WebApi;
 using Altinn.DialogportenAdapter.WebApi.Common.Extensions;
 using Altinn.DialogportenAdapter.WebApi.Features.Command.Sync;
@@ -43,6 +45,7 @@ public class DialogportenAdapterApplication : IAsyncLifetime
     public WireMockServer RegisterApi { get; private set; } = null!;
     public ServiceBusClient ServiceBusClient { get; private set; } = null!;
     private ServiceBusAdministrationClient ServiceBusAdminClient { get; set; } = null!;
+
     private static bool IsDebug =>
 #if DEBUG
         true;
@@ -172,9 +175,13 @@ public class DialogportenAdapterApplication : IAsyncLifetime
             .AddSingleton<SyncCompletionSignal>()
             .ConfigureDialogportenAdapterServices(builder.Configuration, builder.Environment, new QuickClock())
             .RemoveAll<IMaskinportenService>().AddTransient<IMaskinportenService, FakeMaskinportenService>()
+            .RemoveAll<IDialogTokenValidator>().AddTransient<IDialogTokenValidator, FakeDialogTokenValidator>()
             .Decorate<ISyncInstanceToDialogService, SyncInstanceToDialogServiceDecorator>();
 
-        return builder.Build();
+        var app = builder
+            .Build()
+            .RegisterRoutes();
+        return app;
     }
 
     private IHost BuildStorageApplication()

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/DialogportenAdapterApplication.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/DialogportenAdapterApplication.cs
@@ -19,6 +19,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Testcontainers.MsSql;
 using Testcontainers.ServiceBus;
 using WireMock.ResponseBuilders;
@@ -165,6 +166,8 @@ public class DialogportenAdapterApplication : IAsyncLifetime
     {
         var builder = WebApplication.CreateBuilder();
 
+        builder.Logging.AddConsole();
+
         builder
             .Configuration
             .AddLocalDevelopmentSettings(builder.Environment);
@@ -207,6 +210,7 @@ public class DialogportenAdapterApplication : IAsyncLifetime
         builderConfiguration["DialogportenAdapter:Altinn:BaseUri"] = AltinnApi.Url;
         builderConfiguration["DialogportenAdapter:Altinn:InternalStorageEndpoint"] = StorageApi.Url;
         builderConfiguration["DialogportenAdapter:Altinn:InternalRegisterEndpoint"] = RegisterApi.Url;
+        builderConfiguration["DialogportenAdapter:Authentication:JwtBearerWellKnown"] = "https://platform.tt02.altinn.no/authentication/api/v1/openid/.well-known/openid-configuration";
         builderConfiguration["WolverineSettings:ServiceBusConnectionString"] = _asbContainer.GetConnectionString();
         builderConfiguration["WolverineSettings:ManagementConnectionString"] = _asbContainer.GetHttpConnectionString();
         builderConfiguration["WolverineSettings:ListenerCount"] = "3";

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/Token/FakeDialogTokenValidator.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/Common/Token/FakeDialogTokenValidator.cs
@@ -1,0 +1,23 @@
+using System.Security.Claims;
+using Altinn.ApiClients.Dialogporten;
+
+namespace Altinn.DialogportenAdapter.Integration.Tests.Common.Token;
+
+public sealed class FakeDialogTokenValidator : IDialogTokenValidator
+{
+    public IValidationResult Validate(
+        ReadOnlySpan<char> token,
+        Guid? dialogId = null, string[]? requiredActions = null,
+        DialogTokenValidationParameters? options = null
+    )
+    {
+        return new ValidationResult();
+    }
+}
+
+public sealed class ValidationResult : IValidationResult
+{
+    public bool IsValid { get; } = true;
+    public Dictionary<string, List<string>> Errors { get; } = new();
+    public ClaimsPrincipal? ClaimsPrincipal { get; }
+}

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/GetReceiptTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/GetReceiptTest.cs
@@ -42,13 +42,72 @@ public class GetReceiptTest(DialogportenAdapterApplication app) : BaseAdapterInt
     }
 
     [Fact]
+    public async Task GivenGetReceiptCreatesAReceipt()
+    {
+        // Arrange
+        var clientFactory = _app.App.Services.GetRequiredService<IHttpClientFactory>();
+        using var client = clientFactory.CreateClient();
+        ArrangeDefaultsForReceipt(out var dialogId, out var transmissionId);
+
+        // Act
+        var url = $"{GetHostUri()}/storage/dialogporten/api/v1/receipt/{dialogId}/{transmissionId}?lang=en";
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add("Authorization", "Bearer ignored");
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+        body.Should().Be("""
+                          | **Date sent:** | **01.01.2020 / 12:30** |
+                          |:-|:-|
+                          | **Sender:** | 029147*****-testName |
+                          | **Receiver:** | 991825827 |
+                          | **Reference number:** | 87e518ebf653 |
+
+                          A mechanical check has been completed while filling in, but we reserve the right to detect errors during the processing of the case and that other documentation may be necessary. Please provide the reference number in case of any inquiries to the agency.
+                          """);
+    }
+
+    [Fact]
     public async Task GivenPreferHeaderWithTimezoneCreatesAReceiptWithRequestedTimezone()
     {
         // Arrange
         var clientFactory = _app.App.Services.GetRequiredService<IHttpClientFactory>();
         using var client = clientFactory.CreateClient();
-        var dialogId = Guid.Parse("6a6a0c9e-9072-45bd-9b9b-13119dc0356e");
-        var transmissionId = Guid.Parse("407d3e62-078b-49a5-a7a3-84fb58b6aa16");
+        ArrangeDefaultsForReceipt(out var dialogId, out var transmissionId);
+
+        // Act
+        var url = $"{GetHostUri()}/storage/dialogporten/api/v1/receipt/{dialogId}/{transmissionId}?lang=en";
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add("Authorization", "Bearer ignored");
+        request.Headers.Add("Prefer", "timezone=Europe/Oslo");
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var europeOsloTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/Oslo");
+        var expectedTime = europeOsloTimeZone.IsDaylightSavingTime(DateTime.Now)
+            ? "01.01.2020 / 13:30"
+            : "01.01.2020 / 14:30";
+
+        body.Should().Be($"""
+                          | **Date sent:** | **{expectedTime}** |
+                          |:-|:-|
+                          | **Sender:** | 029147*****-testName |
+                          | **Receiver:** | 991825827 |
+                          | **Reference number:** | 87e518ebf653 |
+
+                          A mechanical check has been completed while filling in, but we reserve the right to detect errors during the processing of the case and that other documentation may be necessary. Please provide the reference number in case of any inquiries to the agency.
+                          """);
+    }
+
+    private void ArrangeDefaultsForReceipt(out Guid dialogId, out Guid transmissionId)
+    {
+        dialogId = Guid.Parse("6a6a0c9e-9072-45bd-9b9b-13119dc0356e");
+        transmissionId = Guid.Parse("407d3e62-078b-49a5-a7a3-84fb58b6aa16");
         var partyId = 50123456;
         var instanceId = Guid.Parse("4a92385d-cd09-4b0e-9749-87e518ebf653");
         var org = "991825827";
@@ -74,7 +133,9 @@ public class GetReceiptTest(DialogportenAdapterApplication app) : BaseAdapterInt
                             }
                         ]
                     },
-                    Transmissions = [new TransmissionDto
+                    Transmissions =
+                    [
+                        new TransmissionDto
                         {
                             Id = transmissionId,
                             CreatedAt = transmissionCreatedAt
@@ -133,31 +194,6 @@ public class GetReceiptTest(DialogportenAdapterApplication app) : BaseAdapterInt
             .RespondWith(Response.Create()
                 .WithStatusCode(HttpStatusCode.OK)
                 .WithBody(JsonSerializer.Serialize(CreateTextResource("en"))));
-
-        // Act
-        var url = $"{GetHostUri()}/storage/dialogporten/api/v1/receipt/{dialogId}/{transmissionId}?lang=en";
-        var request = new HttpRequestMessage(HttpMethod.Get, url);
-        request.Headers.Add("Authorization", "Bearer ignored");
-        request.Headers.Add("Prefer", "timezone=Europe/Oslo");
-        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
-
-        // Assert
-        response.EnsureSuccessStatusCode();
-        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        var europeOsloTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/Oslo");
-        var expectedTime = europeOsloTimeZone.IsDaylightSavingTime(DateTime.Now)
-            ? "01.01.2020 / 13:30"
-            : "01.01.2020 / 14:30";
-
-        body.Should().Be($"""
-                          | **Date sent:** | **{expectedTime}** |
-                          |:-|:-|
-                          | **Sender:** | 029147*****-testName |
-                          | **Receiver:** | 991825827 |
-                          | **Reference number:** | 87e518ebf653 |
-
-                          A mechanical check has been completed while filling in, but we reserve the right to detect errors during the processing of the case and that other documentation may be necessary. Please provide the reference number in case of any inquiries to the agency.
-                          """);
     }
 
     private static TextResource CreateTextResource(string language)
@@ -167,7 +203,8 @@ public class GetReceiptTest(DialogportenAdapterApplication app) : BaseAdapterInt
             Id = "1",
             Org = "skd",
             Language = language,
-            Resources = [
+            Resources =
+            [
                 new TextResourceElement
                 {
                     Id = InstanceReceipt.InstanceReceiptSummaryKey,

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/GetReceiptTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/GetReceiptTest.cs
@@ -47,7 +47,9 @@ public class GetReceiptTest(DialogportenAdapterApplication app) : BaseAdapterInt
         // Arrange
         var clientFactory = _app.App.Services.GetRequiredService<IHttpClientFactory>();
         using var client = clientFactory.CreateClient();
-        ArrangeDefaultsForReceipt(out var dialogId, out var transmissionId);
+        var arrangement = ArrangeForReceipt(new DateTimeOffset(2020, 1, 1, 12, 30, 0, TimeSpan.Zero));
+        var dialogId = arrangement.DialogId;
+        var transmissionId =  arrangement.TransmissionId;
 
         // Act
         var url = $"{GetHostUri()}/storage/dialogporten/api/v1/receipt/{dialogId}/{transmissionId}?lang=en";
@@ -71,12 +73,14 @@ public class GetReceiptTest(DialogportenAdapterApplication app) : BaseAdapterInt
     }
 
     [Fact]
-    public async Task GivenPreferHeaderWithTimezoneCreatesAReceiptWithRequestedTimezone()
+    public async Task GivenPreferHeaderWithOsloTimezoneAndReceiptInWinterTimeCreatesAReceiptWithCorrectTime()
     {
         // Arrange
         var clientFactory = _app.App.Services.GetRequiredService<IHttpClientFactory>();
         using var client = clientFactory.CreateClient();
-        ArrangeDefaultsForReceipt(out var dialogId, out var transmissionId);
+        var arrangement = ArrangeForReceipt(new DateTimeOffset(2020, 1, 1, 12, 30, 0, TimeSpan.Zero));
+        var dialogId = arrangement.DialogId;
+        var transmissionId =  arrangement.TransmissionId;
 
         // Act
         var url = $"{GetHostUri()}/storage/dialogporten/api/v1/receipt/{dialogId}/{transmissionId}?lang=en";
@@ -88,13 +92,41 @@ public class GetReceiptTest(DialogportenAdapterApplication app) : BaseAdapterInt
         // Assert
         response.EnsureSuccessStatusCode();
         var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        var europeOsloTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/Oslo");
-        var expectedTime = europeOsloTimeZone.IsDaylightSavingTime(DateTime.Now)
-            ? "01.01.2020 / 13:30"
-            : "01.01.2020 / 14:30";
 
-        body.Should().Be($"""
-                          | **Date sent:** | **{expectedTime}** |
+        body.Should().Be("""
+                          | **Date sent:** | **01.01.2020 / 13:30** |
+                          |:-|:-|
+                          | **Sender:** | 029147*****-testName |
+                          | **Receiver:** | 991825827 |
+                          | **Reference number:** | 87e518ebf653 |
+
+                          A mechanical check has been completed while filling in, but we reserve the right to detect errors during the processing of the case and that other documentation may be necessary. Please provide the reference number in case of any inquiries to the agency.
+                          """);
+    }
+
+    [Fact]
+    public async Task GivenPreferHeaderWithOsloTimezoneAndReceiptInSummerTimeCreatesAReceiptWithCorrectTime()
+    {
+        // Arrange
+        var clientFactory = _app.App.Services.GetRequiredService<IHttpClientFactory>();
+        using var client = clientFactory.CreateClient();
+        var arrangement = ArrangeForReceipt(new DateTimeOffset(2020, 6, 1, 12, 30, 0, TimeSpan.Zero));
+        var dialogId = arrangement.DialogId;
+        var transmissionId =  arrangement.TransmissionId;
+
+        // Act
+        var url = $"{GetHostUri()}/storage/dialogporten/api/v1/receipt/{dialogId}/{transmissionId}?lang=en";
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add("Authorization", "Bearer ignored");
+        request.Headers.Add("Prefer", "timezone=Europe/Oslo");
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+        body.Should().Be("""
+                          | **Date sent:** | **01.06.2020 / 14:30** |
                           |:-|:-|
                           | **Sender:** | 029147*****-testName |
                           | **Receiver:** | 991825827 |
@@ -110,7 +142,9 @@ public class GetReceiptTest(DialogportenAdapterApplication app) : BaseAdapterInt
         // Arrange
         var clientFactory = _app.App.Services.GetRequiredService<IHttpClientFactory>();
         using var client = clientFactory.CreateClient();
-        ArrangeDefaultsForReceipt(out var dialogId, out var transmissionId);
+        var arrangement = ArrangeForReceipt(new DateTimeOffset(2020, 1, 1, 12, 30, 0, TimeSpan.Zero));
+        var dialogId = arrangement.DialogId;
+        var transmissionId =  arrangement.TransmissionId;
 
         // Act
         var url = $"{GetHostUri()}/storage/dialogporten/api/v1/receipt/{dialogId}/{transmissionId}?lang=en";
@@ -134,17 +168,18 @@ public class GetReceiptTest(DialogportenAdapterApplication app) : BaseAdapterInt
                          """);
     }
 
-    private void ArrangeDefaultsForReceipt(out Guid dialogId, out Guid transmissionId)
+    private sealed record ReceiptArrangement(Guid DialogId, Guid TransmissionId);
+
+    private ReceiptArrangement ArrangeForReceipt(DateTimeOffset transmissionCreatedAt)
     {
-        dialogId = Guid.Parse("6a6a0c9e-9072-45bd-9b9b-13119dc0356e");
-        transmissionId = Guid.Parse("407d3e62-078b-49a5-a7a3-84fb58b6aa16");
+        var dialogId = Guid.Parse("6a6a0c9e-9072-45bd-9b9b-13119dc0356e");
+        var transmissionId = Guid.Parse("407d3e62-078b-49a5-a7a3-84fb58b6aa16");
         var partyId = 50123456;
         var instanceId = Guid.Parse("4a92385d-cd09-4b0e-9749-87e518ebf653");
         var org = "991825827";
         var appId = $"{org}/123";
         var partyUrn = "urn:altinn:person:identifier-no:02914797589";
 
-        var transmissionCreatedAt = new DateTimeOffset(2020, 1, 1, 12, 30, 0, TimeSpan.Zero);
         _app.DialogportenApi
             .Given(Request.Create().DpGetDialog(dialogId))
             .RespondWith(Response.Create()
@@ -224,6 +259,8 @@ public class GetReceiptTest(DialogportenAdapterApplication app) : BaseAdapterInt
             .RespondWith(Response.Create()
                 .WithStatusCode(HttpStatusCode.OK)
                 .WithBody(JsonSerializer.Serialize(CreateTextResource("en"))));
+
+        return new ReceiptArrangement(dialogId, transmissionId);
     }
 
     private static TextResource CreateTextResource(string language)

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/GetReceiptTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/GetReceiptTest.cs
@@ -104,6 +104,36 @@ public class GetReceiptTest(DialogportenAdapterApplication app) : BaseAdapterInt
                           """);
     }
 
+    [Fact]
+    public async Task GivenBadTimezoneInPreferHeaderReturnsReceiptInUtc()
+    {
+        // Arrange
+        var clientFactory = _app.App.Services.GetRequiredService<IHttpClientFactory>();
+        using var client = clientFactory.CreateClient();
+        ArrangeDefaultsForReceipt(out var dialogId, out var transmissionId);
+
+        // Act
+        var url = $"{GetHostUri()}/storage/dialogporten/api/v1/receipt/{dialogId}/{transmissionId}?lang=en";
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add("Authorization", "Bearer ignored");
+        request.Headers.Add("Prefer", "timezone=Europee/Oslo");
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+        body.Should().Be("""
+                         | **Date sent:** | **01.01.2020 / 12:30** |
+                         |:-|:-|
+                         | **Sender:** | 029147*****-testName |
+                         | **Receiver:** | 991825827 |
+                         | **Reference number:** | 87e518ebf653 |
+
+                         A mechanical check has been completed while filling in, but we reserve the right to detect errors during the processing of the case and that other documentation may be necessary. Please provide the reference number in case of any inquiries to the agency.
+                         """);
+    }
+
     private void ArrangeDefaultsForReceipt(out Guid dialogId, out Guid transmissionId)
     {
         dialogId = Guid.Parse("6a6a0c9e-9072-45bd-9b9b-13119dc0356e");

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/GetReceiptTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/GetReceiptTest.cs
@@ -1,0 +1,180 @@
+using System.Net;
+using System.Text.Json;
+using Altinn.DialogportenAdapter.Integration.Tests.Common;
+using Altinn.DialogportenAdapter.Integration.Tests.Common.Extensions;
+using Altinn.DialogportenAdapter.Test.Common.Builder;
+using Altinn.DialogportenAdapter.WebApi.Features.Command.Sync;
+using Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
+using Altinn.DialogportenAdapter.WebApi.Infrastructure.Register;
+using Altinn.Platform.Storage.Interface.Models;
+using AwesomeAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using WireMock.RequestBuilders;
+using Xunit;
+using Response = WireMock.ResponseBuilders.Response;
+
+namespace Altinn.DialogportenAdapter.Integration.Tests.WebApi;
+
+[Collection(nameof(AdapterCollectionFixture))]
+public class GetReceiptTest(DialogportenAdapterApplication app) : BaseAdapterIntegrationTest(app)
+{
+    private readonly DialogportenAdapterApplication _app = app;
+
+    [Fact]
+    public async Task GivenPreflightRequestFromAllowedOriginReturnsExpectedAccessControlHeaders()
+    {
+        // Act
+        var clientFactory = _app.App.Services.GetRequiredService<IHttpClientFactory>();
+        using var client = clientFactory.CreateClient();
+        var url = $"{GetHostUri()}/storage/dialogporten/api/v1/receipt/{Guid.NewGuid()}/{Guid.NewGuid()}?lang=en";
+        var request = new HttpRequestMessage(HttpMethod.Options, url);
+        request.Headers.Add("Authorization", "Bearer ignored");
+        request.Headers.Add("Origin", "af.altinn.no");
+        request.Headers.Add("Access-Control-Request-Method", "GET");
+        request.Headers.Add("Access-Control-Request-Headers", "Authorization, Prefer");
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        response.Headers.GetValues("Access-Control-Allow-Origin").Single().Should().Be("*");
+        response.Headers.GetValues("Access-Control-Allow-Methods").Single().Should().Be("GET");
+        response.Headers.GetValues("Access-Control-Allow-Headers").Should().BeEquivalentTo("Authorization,Prefer");
+    }
+
+    [Fact]
+    public async Task GivenPreferHeaderWithTimezoneCreatesAReceiptWithRequestedTimezone()
+    {
+        // Arrange
+        var clientFactory = _app.App.Services.GetRequiredService<IHttpClientFactory>();
+        using var client = clientFactory.CreateClient();
+        var dialogId = Guid.Parse("6a6a0c9e-9072-45bd-9b9b-13119dc0356e");
+        var transmissionId = Guid.Parse("407d3e62-078b-49a5-a7a3-84fb58b6aa16");
+        var partyId = 50123456;
+        var instanceId = Guid.Parse("4a92385d-cd09-4b0e-9749-87e518ebf653");
+        var org = "991825827";
+        var appId = $"{org}/123";
+        var partyUrn = "urn:altinn:person:identifier-no:02914797589";
+
+        var transmissionCreatedAt = new DateTimeOffset(2020, 1, 1, 12, 30, 0, TimeSpan.Zero);
+        _app.DialogportenApi
+            .Given(Request.Create().DpGetDialog(dialogId))
+            .RespondWith(Response.Create()
+                .WithStatusCode(HttpStatusCode.OK)
+                .WithBody(JsonSerializer.Serialize(new DialogDto
+                {
+                    Org = org,
+                    Party = partyUrn,
+                    ServiceOwnerContext = new ServiceOwnerContext
+                    {
+                        ServiceOwnerLabels =
+                        [
+                            new ServiceOwnerLabel
+                            {
+                                Value = $"urn:altinn:integration:storage:{partyId}/{instanceId}"
+                            }
+                        ]
+                    },
+                    Transmissions = [new TransmissionDto
+                        {
+                            Id = transmissionId,
+                            CreatedAt = transmissionCreatedAt
+                        }
+                    ]
+                })));
+
+        _app.StorageApi
+            .Given(Request.Create().StorageGetInstance(partyId, instanceId))
+            .RespondWith(Response.Create()
+                .WithStatusCode(HttpStatusCode.OK)
+                .WithBody(JsonSerializer.Serialize(AltinnInstanceBuilder
+                    .NewInProgressInstance()
+                    .WithId(instanceId.ToString())
+                    .WithAppId(appId)
+                    .Build())));
+
+        _app.StorageApi
+            .Given(Request.Create().StorageGetApplication(appId))
+            .RespondWith(Response.Create()
+                .WithStatusCode(HttpStatusCode.OK)
+                .WithBody(JsonSerializer.Serialize(
+                    AltinnApplicationBuilder
+                        .NewDefaultAltinnApplication()
+                        .WithVersionId("versionId")
+                        .Build()
+                )));
+
+        _app.RegisterApi
+            .Given(Request.Create().RegisterPostPartySearch())
+            .RespondWith(Response.Create()
+                .WithStatusCode(HttpStatusCode.OK)
+                .WithBody(JsonSerializer.Serialize(new PartyQueryResponse([
+                    new PartyIdentifier(
+                        PartyId: partyId,
+                        PartyType: "person",
+                        PersonIdentifier: "02914797589",
+                        OrganizationIdentifier: null,
+                        ExternalUrn: partyUrn,
+                        DisplayName: "testName"
+                    )
+                ]))));
+
+        _app.StorageApi
+            .Given(Request.Create().StorageGetApplicationTexts(appId, "nb"))
+            .RespondWith(Response.Create()
+                .WithStatusCode(HttpStatusCode.OK)
+                .WithBody(JsonSerializer.Serialize(CreateTextResource("nb"))));
+        _app.StorageApi
+            .Given(Request.Create().StorageGetApplicationTexts(appId, "nn"))
+            .RespondWith(Response.Create()
+                .WithStatusCode(HttpStatusCode.OK)
+                .WithBody(JsonSerializer.Serialize(CreateTextResource("nn"))));
+        _app.StorageApi
+            .Given(Request.Create().StorageGetApplicationTexts(appId, "en"))
+            .RespondWith(Response.Create()
+                .WithStatusCode(HttpStatusCode.OK)
+                .WithBody(JsonSerializer.Serialize(CreateTextResource("en"))));
+
+        // Act
+        var url = $"{GetHostUri()}/storage/dialogporten/api/v1/receipt/{dialogId}/{transmissionId}?lang=en";
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add("Authorization", "Bearer ignored");
+        request.Headers.Add("Prefer", "timezone=Europe/Oslo");
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var europeOsloTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/Oslo");
+        var expectedTime = europeOsloTimeZone.IsDaylightSavingTime(DateTime.Now)
+            ? "01.01.2020 / 13:30"
+            : "01.01.2020 / 14:30";
+
+        body.Should().Be($"""
+                          | **Date sent:** | **{expectedTime}** |
+                          |:-|:-|
+                          | **Sender:** | 029147*****-testName |
+                          | **Receiver:** | 991825827 |
+                          | **Reference number:** | 87e518ebf653 |
+
+                          A mechanical check has been completed while filling in, but we reserve the right to detect errors during the processing of the case and that other documentation may be necessary. Please provide the reference number in case of any inquiries to the agency.
+                          """);
+    }
+
+    private static TextResource CreateTextResource(string language)
+    {
+        return new TextResource()
+        {
+            Id = "1",
+            Org = "skd",
+            Language = language,
+            Resources = [
+                new TextResourceElement
+                {
+                    Id = InstanceReceipt.InstanceReceiptSummaryKey,
+                    Value = "summary",
+                    Variables = null
+                }
+            ]
+        };
+    }
+}

--- a/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/GetReceiptTest.cs
+++ b/tests/Altinn.DialogportenAdapter.Integration.Tests/WebApi/GetReceiptTest.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Altinn.DialogportenAdapter.Integration.Tests.Common;
 using Altinn.DialogportenAdapter.Integration.Tests.Common.Extensions;
 using Altinn.DialogportenAdapter.Test.Common.Builder;
+using Altinn.DialogportenAdapter.Test.Common.Extensions;
 using Altinn.DialogportenAdapter.WebApi.Features.Command.Sync;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Dialogporten;
 using Altinn.DialogportenAdapter.WebApi.Infrastructure.Register;
@@ -35,7 +36,7 @@ public class GetReceiptTest(DialogportenAdapterApplication app) : BaseAdapterInt
         var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
-        response.EnsureSuccessStatusCode();
+        response.ShouldBeSuccess();
         response.Headers.GetValues("Access-Control-Allow-Origin").Single().Should().Be("*");
         response.Headers.GetValues("Access-Control-Allow-Methods").Single().Should().Be("GET");
         response.Headers.GetValues("Access-Control-Allow-Headers").Should().BeEquivalentTo("Authorization,Prefer");
@@ -58,7 +59,7 @@ public class GetReceiptTest(DialogportenAdapterApplication app) : BaseAdapterInt
         var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
-        response.EnsureSuccessStatusCode();
+        response.ShouldBeSuccess();
         var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         body.Should().Be("""
@@ -90,7 +91,7 @@ public class GetReceiptTest(DialogportenAdapterApplication app) : BaseAdapterInt
         var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
-        response.EnsureSuccessStatusCode();
+        response.ShouldBeSuccess();
         var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         body.Should().Be("""
@@ -122,7 +123,7 @@ public class GetReceiptTest(DialogportenAdapterApplication app) : BaseAdapterInt
         var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
-        response.EnsureSuccessStatusCode();
+        response.ShouldBeSuccess();
         var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         body.Should().Be("""
@@ -154,7 +155,7 @@ public class GetReceiptTest(DialogportenAdapterApplication app) : BaseAdapterInt
         var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
-        response.EnsureSuccessStatusCode();
+        response.ShouldBeSuccess();
         var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         body.Should().Be("""

--- a/tests/Altinn.DialogportenAdapter.Test.Common/Altinn.DialogportenAdapter.Test.Common.csproj
+++ b/tests/Altinn.DialogportenAdapter.Test.Common/Altinn.DialogportenAdapter.Test.Common.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="Altinn.Platform.Storage.Interface" Version="4.7.1" />
+    <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
   </ItemGroup>
 </Project>

--- a/tests/Altinn.DialogportenAdapter.Test.Common/Extensions/HttpResponseMessageExtensions.cs
+++ b/tests/Altinn.DialogportenAdapter.Test.Common/Extensions/HttpResponseMessageExtensions.cs
@@ -1,0 +1,18 @@
+using AwesomeAssertions;
+
+namespace Altinn.DialogportenAdapter.Test.Common.Extensions;
+
+public static class HttpResponseExtensions
+{
+    extension(HttpResponseMessage message)
+    {
+        public void ShouldBeSuccess()
+        {
+            if (message.IsSuccessStatusCode) return;
+            var body = message.Content.ReadAsStringAsync().Result;
+            var bodyReason = string.IsNullOrEmpty(body) ? " Body was null/empty" : $" Body: {body}";
+            message.IsSuccessStatusCode.Should()
+                .BeTrue("Status code should be successful, but was {0}.{1}", (int)message.StatusCode, bodyReason);
+        }
+    }
+}

--- a/tests/Altinn.DialogportenAdapter.Unit.Tests/Altinn.DialogportenAdapter.Unit.Tests.csproj
+++ b/tests/Altinn.DialogportenAdapter.Unit.Tests/Altinn.DialogportenAdapter.Unit.Tests.csproj
@@ -12,7 +12,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
         <PackageReference Include="NSubstitute" Version="5.3.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/InstanceReceiptTests.cs
+++ b/tests/Altinn.DialogportenAdapter.Unit.Tests/Features/Command/Sync/InstanceReceiptTests.cs
@@ -25,7 +25,7 @@ public class InstanceReceiptTests
         var (sut, _, _, _, _, _) = CreateSut();
 
         var result = await sut.GetReceipt(
-            new GetReceiptDto(Guid.NewGuid(), Guid.NewGuid(), "de"),
+            new GetReceiptDto(Guid.NewGuid(), Guid.NewGuid(), "de", null),
             CancellationToken.None);
 
         Assert.IsType<GetReceiptResponse.InvalidLanguageCode>(result);
@@ -41,7 +41,7 @@ public class InstanceReceiptTests
         var (sut, _, _, _, _, _) = CreateSut(dialogApi: dialogApi);
 
         var result = await sut.GetReceipt(
-            new GetReceiptDto(Guid.NewGuid(), Guid.NewGuid(), "nb"),
+            new GetReceiptDto(Guid.NewGuid(), Guid.NewGuid(), "nb", null),
             CancellationToken.None);
 
         Assert.IsType<GetReceiptResponse.NotFound>(result);
@@ -59,7 +59,7 @@ public class InstanceReceiptTests
         var (sut, _, _, _, _, _) = CreateSutFromData(data);
 
         var result = await sut.GetReceipt(
-            new GetReceiptDto(data.DialogId, data.TransmissionId, "nb"),
+            new GetReceiptDto(data.DialogId, data.TransmissionId, "nb", null),
             CancellationToken.None);
 
         Assert.IsType<GetReceiptResponse.NotFound>(result);
@@ -75,7 +75,7 @@ public class InstanceReceiptTests
                 ApiNotFound<Instance>()));
 
         var result = await sut.GetReceipt(
-            new GetReceiptDto(data.DialogId, data.TransmissionId, "nb"),
+            new GetReceiptDto(data.DialogId, data.TransmissionId, "nb", null),
             CancellationToken.None);
 
         Assert.IsType<GetReceiptResponse.NotFound>(result);
@@ -90,7 +90,7 @@ public class InstanceReceiptTests
             .Returns((Application?)null);
 
         var result = await sut.GetReceipt(
-            new GetReceiptDto(data.DialogId, data.TransmissionId, "nb"),
+            new GetReceiptDto(data.DialogId, data.TransmissionId, "nb", null),
             CancellationToken.None);
 
         Assert.IsType<GetReceiptResponse.NotFound>(result);
@@ -104,7 +104,7 @@ public class InstanceReceiptTests
         var (sut, _, _, _, _, _) = CreateSutFromData(data);
 
         var result = await sut.GetReceipt(
-            new GetReceiptDto(data.DialogId, missingTransmissionId, "nb"),
+            new GetReceiptDto(data.DialogId, missingTransmissionId, "nb", null),
             CancellationToken.None);
 
         Assert.IsType<GetReceiptResponse.NotFound>(result);
@@ -119,7 +119,7 @@ public class InstanceReceiptTests
             .Returns((AltinnOrgData?)null);
 
         var result = await sut.GetReceipt(
-            new GetReceiptDto(data.DialogId, data.TransmissionId, "nb"),
+            new GetReceiptDto(data.DialogId, data.TransmissionId, "nb", null),
             CancellationToken.None);
 
         var success = Assert.IsType<GetReceiptResponse.Success>(result);
@@ -131,13 +131,35 @@ public class InstanceReceiptTests
     }
 
     [Fact]
+    public async Task GetReceipt_HappyPathWithTimezone_ReturnsMarkdown()
+    {
+        var data = CreateHappyPathData();
+        var (sut, _, _, _, _, _) = CreateSutFromData(data);
+
+        var result = await sut.GetReceipt(
+            new GetReceiptDto(data.DialogId, data.TransmissionId, "nb", "Prefer: timezone=UTC"),
+            CancellationToken.None
+        );
+
+        var success = Assert.IsType<GetReceiptResponse.Success>(result);
+        Assert.Contains("**Dato sendt:** | **20.03.2026 / 10:00**", success.Markdown);
+        Assert.Contains("Avsender:", success.Markdown);
+        Assert.Contains("123456*****-Ola Nordmann", success.Markdown);
+        Assert.Contains("Mottaker", success.Markdown);
+        Assert.Contains("Digitaliseringsdirektoratet", success.Markdown);
+        Assert.Contains("Referansenummer", success.Markdown);
+        Assert.Contains("123456789abc", success.Markdown);
+        Assert.Contains("Det er gjennomført en maskinell kontroll under utfylling", success.Markdown);
+    }
+
+    [Fact]
     public async Task GetReceipt_HappyPath_ReturnsMarkdownNb()
     {
         var data = CreateHappyPathData();
         var (sut, _, _, _, _, _) = CreateSutFromData(data);
 
         var result = await sut.GetReceipt(
-            new GetReceiptDto(data.DialogId, data.TransmissionId, "nb"),
+            new GetReceiptDto(data.DialogId, data.TransmissionId, "nb", null),
             CancellationToken.None);
 
         var success = Assert.IsType<GetReceiptResponse.Success>(result);
@@ -158,7 +180,7 @@ public class InstanceReceiptTests
         var (sut, _, _, _, _, _) = CreateSutFromData(data);
 
         var result = await sut.GetReceipt(
-            new GetReceiptDto(data.DialogId, data.TransmissionId, "nn"),
+            new GetReceiptDto(data.DialogId, data.TransmissionId, "nn", null),
             CancellationToken.None);
 
         var success = Assert.IsType<GetReceiptResponse.Success>(result);
@@ -179,7 +201,7 @@ public class InstanceReceiptTests
         var (sut, _, _, _, _, _) = CreateSutFromData(data);
 
         var result = await sut.GetReceipt(
-            new GetReceiptDto(data.DialogId, data.TransmissionId, "en"),
+            new GetReceiptDto(data.DialogId, data.TransmissionId, "en", null),
             CancellationToken.None);
 
         var success = Assert.IsType<GetReceiptResponse.Success>(result);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- https://github.com/Altinn/dialogporten/issues/4254

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added versioned API routes for dialog synchronization, instance deletion, and receipt retrieval.
  - Receipt timestamps can be formatted in a requested timezone through the `Prefer` header.
  - Added health and OpenAPI endpoints with improved validation and error responses.

- **Bug Fixes**
  - Invalid timezone preferences now fall back safely to the original receipt timestamp offset.

- **Tests**
  - Expanded coverage for receipts, timezone handling, CORS preflight requests, and API behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->